### PR TITLE
Documentation fixing: sbt ~compile --> sbt "~compile"

### DIFF
--- a/doc/sphinx/dev.rst
+++ b/doc/sphinx/dev.rst
@@ -63,11 +63,12 @@ automatically reload the generated .class files.
 If you use a plain text editor, not Eclipse:
 
 1. Run ``sbt run``
-2. Run ``sbt "~compile"`` in another console to compile in continuous/incremental mode
+2. Run ``sbt "~compile"`` in another console to compile in
+continuous/incremental mode
 3. In the editor, try editing a Scala file, and save
 
-The ``sbt ~compile`` process will automatically recompile the file, and JRebel will
-automatically reload the generated .class files.
+The ``sbt "~compile"`` process will automatically recompile the file, and
+JRebel will automatically reload the generated .class files.
 
 Routes are not reloaded
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Dear Ngoc-san,

`~compile` would be expanded to `/home/compile` in most *nix systems.  I've changed it to `"~compile"` to prevent that.  Please merge it if necessary.
