### PR TITLE
add a note about continuations + sessions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ and `Hazelcast <http://www.hazelcast.com/>`_:
   to respond immediately. Chunked response (streaming), WebSocket, and Comet
   (using WebSocket or long-polling) are supported.
 * Sessions can be stored in cookies (more scalable) or clustered Hazelcast (more secure).
+  Hazelcast is recommended when using continuations-based Actions, since serialized
+  continuations are usually too big to store in cookies.
 * `jQuery Validation <http://docs.jquery.com/Plugins/validation>`_ is integrated
   for browser side and server side validation.
 * i18n using `GNU gettext <http://en.wikipedia.org/wiki/GNU_gettext>`_.


### PR DESCRIPTION
Hazelcast should be used to handle sessions when continuations-based Actions are used, since the continuations are serialized and stored in the user's session, and can get too big to hold within a cookie (not to mention the serious security risk of storing a continuation on the client side, where it can be changed by the user).
