### PR TITLE
X-csrf-token

### DIFF
--- a/src/main/scala/xitrum/scope/session/Csrf.scala
+++ b/src/main/scala/xitrum/scope/session/Csrf.scala
@@ -12,11 +12,13 @@ import xitrum.util.SecureUrlSafeBase64
  */
 object Csrf {
   val TOKEN = "csrf-token"
+  val XTOKEN = s"X-${TOKEN}"
 
   def isValidToken(action: Action): Boolean = {
     // The token must be in the request body for more security
     val bodyParams     = action.handlerEnv.bodyParams
-    val tokenInRequest = action.param(TOKEN, bodyParams)
+    val headers        = action.handlerEnv.request.headers
+    val tokenInRequest = Option(headers.get(XTOKEN)).getOrElse(action.param(TOKEN, bodyParams))
 
     // Cleaner for application developers when seeing access log
     bodyParams.remove(TOKEN)


### PR DESCRIPTION
Now csrf-token passed only in body params. I add lookup in request headers. For perfomance reason some time post body contains huge raw binary data, and adding csrf-token to body is not possible. In this case csrf token can be sended throught `X-csrf-token` request header. Client side example:

``` coffeescript
  array = new Uint8Array(contents);

  $.ajax 
    url: '/xhr/save/push'
    type: 'POST'
    data: array
    processData: false
    contentType: 'application/octet-stream'
    beforeSend: (request) ->
      request.setRequestHeader('X-Profile', JSON.stringify(Epicport['profile']))
      request.setRequestHeader('X-csrf-token', $("meta[name='csrf-token']").attr("content"))
    success: (resp) ->
      Epicport.modalMessage("Success", "Game saved on server")
    error: (xhr, state, error) ->
      status = xhr.status || 500
      error  = error || "Unknown error"

      Epicport.modalMessage("Error (" + status+ ")", "(" + status + "): " + error)
```
