### PR TITLE
i18n improvements

### DIFF
--- a/src/main/scala/xitrum/i18n/PoLoader.scala
+++ b/src/main/scala/xitrum/i18n/PoLoader.scala
@@ -12,7 +12,8 @@ object PoLoader {
 
   /**
    * @return Merge of all po files of the language, or an empty Po when there's
-   * no po file.
+   * no po file. Store Po in cache for further fast access. Use the {@link #clear() clear}
+   * method to clean cache.
    */
   def load(language: String): Po = synchronized {
     if (cache.isDefinedAt(language)) return cache(language)
@@ -30,5 +31,12 @@ object PoLoader {
     val ret = buffer.foldLeft(new Po(Map.empty)) { (acc, e) => acc ++ e }
     cache(language) = ret
     ret
+  }
+  
+  /**
+   * Clear the cache of the already loaded Po files
+   */
+  def clear() = synchronized {
+    cache.clear
   }
 }

--- a/src/test/scala/xitrum/etag/EtagTest.scala
+++ b/src/test/scala/xitrum/etag/EtagTest.scala
@@ -1,0 +1,35 @@
+package xitrum.etag
+
+import org.scalatest.Matchers
+import org.scalatest.FlatSpec
+import java.io.File
+import java.io.FileOutputStream
+
+class EtagTest extends FlatSpec with Matchers {
+  
+  behavior of "ETag"
+
+  it should "stay same while file is not modified" in {
+    val file     = File.createTempFile("etag", "test")
+    val filePath = file.getAbsoluteFile().toString()
+    file.deleteOnExit()
+    
+    val result = Etag.forFile(filePath, false)
+    
+    val etag = result match {
+      case Etag.Small(_, etag, _, _) => etag
+      case _ => fail()
+    }
+    
+    etag should equal (Etag.forFile(filePath, false).asInstanceOf[Etag.Small].etag)
+    
+    Thread.sleep(1000)
+    
+    val stream = new FileOutputStream(file)
+    stream.write(1)
+    stream.close()
+    
+    etag should not equal (Etag.forFile(filePath, false).asInstanceOf[Etag.Small].etag)
+  }
+  
+}

--- a/src/test/scala/xitrum/scope/request/RequestEnvTest.scala
+++ b/src/test/scala/xitrum/scope/request/RequestEnvTest.scala
@@ -7,7 +7,7 @@ import xitrum.Action
 class RequestEnvTest extends FlatSpec with Matchers {
   behavior of "RequestEnv"
 
-  it should "should have atJs method" in {
+  it should "should have atJson method" in {
     val action = new Action { def execute() {} }
 
     action.at("test_string") = "abc"


### PR DESCRIPTION
The key feature of this pull request is a possibility to reload *.po files without restarting xitrum app. With this changes user can specify folders in file system where po files are located. To do this it should add in xitrum.conf (for example):

``` javascript
  i18n {
    lookupFolders = ["public/i18n"]
  }
```

When app starts PoLoader will merge all po files from resources + lookup folders which users set. Additionally when file in folder changed PoLoader will automatically reload it. To avoid slowdowns with checking modifying date on each request i add fastCache that take po file for 5 minute. So in production mode po file will reload when neaded but with 5 minute interval. I'm really not sure whether this provides a performance boost.

That's roughly what I need at the moment, i can refactor/reimplement if needed fill free to leave feedback.
