### PR TITLE
Make respondSockJsXxx return Future like other respondXxx methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
 3.22:
 
+* `#503 <https://github.com/xitrum-framework/xitrum/issues/503>`_
+  Make respondSockJsXxx return Future like other respondXxx methods
 * `#459 <https://github.com/xitrum-framework/xitrum/issues/459>`_
   Optimize route collecting: Ignore more packages that obviously don't contain routes
 * `#495 <https://github.com/xitrum-framework/xitrum/issues/495>`_


### PR DESCRIPTION
This PR is against xitrum-framework/xitrum#503.

@ngocdaothanh 
I'm not sure about how to get [EventExecutor](http://netty.io/4.0/api/io/netty/util/concurrent/EventExecutor.html) for DefaultPromise.  
Actually `channel.eventLoop` is available but can I use it in Actor(SockJSAction).

```scala
private def createPromise(index: Int):Future[String] = {
  val p = new DefaultPromise[String](channel.eventLoop)
  promises(index) = p
  p
}
```