### PR TITLE
Enable to stop xitrum server.

### DIFF
--- a/src/main/scala/xitrum/handler/FlashSocketPolicyServer.scala
+++ b/src/main/scala/xitrum/handler/FlashSocketPolicyServer.scala
@@ -1,13 +1,13 @@
 package xitrum.handler
 
-import io.netty.channel.ChannelInitializer
+import io.netty.channel.{ChannelInitializer, EventLoopGroup}
 import io.netty.channel.socket.SocketChannel
 
 import xitrum.{Config, Log}
 import xitrum.handler.inbound.FlashSocketPolicyHandler
 
 object FlashSocketPolicyServer {
-  def start() {
+  def start(): Seq[EventLoopGroup] = {
     val (bootstrap, groups) = Bootstrap.newBootstrap(newChannelInitializer())
 
     val port = Config.xitrum.port.flashSocketPolicy.get
@@ -15,6 +15,7 @@ object FlashSocketPolicyServer {
     NetOption.bind("flash socket", bootstrap, port, groups)
 
     Log.info(s"Flash socket policy server started on port $port")
+    groups
   }
 
   private def newChannelInitializer(): ChannelInitializer[SocketChannel] = {


### PR DESCRIPTION
This PR is against #504.

We can stop xitrum server in 2 way.

1. 
```scala
Server.stop()
```

2.
```scala
val started = Server.start()
started.foreach(_.shutdownGracefully())
```