### PR TITLE
Respond 400 Bad Request when params in request URI can't be decoded

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@
   Make respondSockJsXxx return Future like other respondXxx methods
 * `#504 <https://github.com/xitrum-framework/xitrum/issues/504>`_
   The result of xitrum.Server.start can be used to stop the server
+* `#508 <https://github.com/xitrum-framework/xitrum/issues/508>`_
+  Respond 400 Bad Request when params in request URI or body can't be decoded
 * `#459 <https://github.com/xitrum-framework/xitrum/issues/459>`_
   Optimize route collecting: Ignore more packages that obviously don't contain routes
 * `#495 <https://github.com/xitrum-framework/xitrum/issues/495>`_

--- a/src/main/scala/xitrum/handler/inbound/BadClientSilencer.scala
+++ b/src/main/scala/xitrum/handler/inbound/BadClientSilencer.scala
@@ -1,8 +1,18 @@
 package xitrum.handler.inbound
 
-import io.netty.channel.{ChannelHandler, ChannelHandlerContext, SimpleChannelInboundHandler}
+import io.netty.buffer.Unpooled
+import io.netty.channel.{Channel, ChannelHandler, ChannelHandlerContext, ChannelFutureListener, SimpleChannelInboundHandler}
 import ChannelHandler.Sharable
-import xitrum.Log
+import io.netty.handler.codec.http.{DefaultFullHttpResponse, HttpVersion, HttpResponseStatus}
+import xitrum.{Config, Log}
+
+object BadClientSilencer {
+  def respond400(channel: Channel, body: String) {
+    val content  = Unpooled.copiedBuffer(body, Config.xitrum.request.charset)
+    val response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.BAD_REQUEST, content)
+    channel.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+  }
+}
 
 /**
  * This handler should be put at the last position of the inbound pipeline to

--- a/src/main/scala/xitrum/handler/inbound/UriParser.scala
+++ b/src/main/scala/xitrum/handler/inbound/UriParser.scala
@@ -35,7 +35,10 @@ class UriParser extends SimpleChannelInboundHandler[HandlerEnv] {
       case NonFatal(e) =>
         val msg = "Could not parse query params URI: " + request.getUri
         Log.warn(msg, e)
-        ctx.channel.close()
+        // https://github.com/xitrum-framework/xitrum/issues/508#issuecomment-72808997
+        // Do not close channel without responding status code.
+        // Nginx decides that upstream is down if upstream drop connection without responding status code.
+        BadClientSilencer.respond400(ctx.channel, "Server could not parse params in URI")
     }
   }
 


### PR DESCRIPTION
This PR is against #508 and its comments.

Respond 400 Bad Request right at [`UriParser`](https://github.com/xitrum-framework/xitrum/blob/master/src/main/scala/xitrum/handler/inbound/UriParser.scala) when could not parse query params.
