### PR TITLE
PR for #512 Feature request: needed more control over netty configuratio...

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@
 * `#508 <https://github.com/xitrum-framework/xitrum/issues/508>`_
   Respond 400 Bad Request when params in request URI or body can't be decoded,
   not just closing the connection
+* `#512 <https://github.com/xitrum-framework/xitrum/issues/512>`_
+  Feature request: needed more control over netty configuration
 * `#511 <https://github.com/xitrum-framework/xitrum/issues/511>`_
   Update RhinoCoffeeScript from 1.8.0 to 1.9.0
 

--- a/src/main/scala/xitrum/Config.scala
+++ b/src/main/scala/xitrum/Config.scala
@@ -120,7 +120,8 @@ class StaticFileConfig(config: TConfig) {
 class RequestConfig(config: TConfig) {
   val charsetName               = config.getString("charset")
   val charset                   = Charset.forName(charsetName)
-  val maxInitialLineLength      = config.getInt("maxInitialLineLength")
+  val maxInitialLineLength      = if (config.hasPath("maxInitialLineLength")) config.getInt("maxInitialLineLength") else 4096
+  val maxHeaderSize             = if (config.hasPath("maxHeaderSize"))        config.getInt("maxHeaderSize")        else 8192
   val maxSizeInBytes            = config.getLong("maxSizeInMB") * 1024 * 1024
   val maxSizeInBytesOfUploadMem =
     if (config.hasPath("maxSizeInKBOfUploadMem"))

--- a/src/main/scala/xitrum/handler/DefaultHttpChannelInitializer.scala
+++ b/src/main/scala/xitrum/handler/DefaultHttpChannelInitializer.scala
@@ -114,7 +114,10 @@ class DefaultHttpChannelInitializer extends ChannelInitializer[SocketChannel] {
 
     if (portConfig.flashSocketPolicy.isDefined && portConfig.flashSocketPolicy == portConfig.http)
     p.addLast(classOf[FlashSocketPolicyHandler].getName, new FlashSocketPolicyHandler)
-    p.addLast(classOf[HttpRequestDecoder].getName,       new HttpRequestDecoder(Config.xitrum.request.maxInitialLineLength, 8192, 8192))
+    p.addLast(classOf[HttpRequestDecoder].getName,       new HttpRequestDecoder(
+                                                           Config.xitrum.request.maxInitialLineLength,
+                                                           Config.xitrum.request.maxHeaderSize,
+                                                           8192))
     p.addLast(classOf[Request2Env].getName,              new Request2Env)
     p.addLast(classOf[BaseUrlRemover].getName,           baseUrlRemover)
     if (Config.xitrum.basicAuth.isDefined)


### PR DESCRIPTION
This PR is against #512.

xitrum.conf also should be changed like this.
```
  request {
    charset = UTF-8

    # Initial line example: "GET / HTTP/1.1".
    # Adjust this when you use very long URL, e.g. send a lot of data with GET method.
    maxInitialLineLength = 4096

+    # The maximum length of all headers.
+    # Adjust this when you use very long header, e.g. search engines may add long Referer header to request.
+    maxHeaderSize = 8192
+  
+    # The maximum length of the content or each chunk.
+    # If the content length exceeds this value, the transfer encoding of the decoded request will be converted to 'chunked' and the content will be split into multiple HttpContents.
+    # If the transfer encoding of the HTTP request is 'chunked' already, each chunk will be split into smaller chunks if the length of the chunk exceeds this value.
+    maxChunkSize = 8192
```