### PR TITLE
Fix #555 Log error message when ssl certificate file not found

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 
 * `#541 <https://github.com/xitrum-framework/xitrum/issues/541>`_
   routes.cache should be saved in tmpDir as configured in xitrum.conf
+* `#555 <https://github.com/xitrum-framework/xitrum/issues/555>`_
+  Log error message when ssl certificate file not found
 * `#548 <https://github.com/xitrum-framework/xitrum/issues/548>`_
   Update Netty from 4.0.28 to 4.0.30
 * `#554 <https://github.com/xitrum-framework/xitrum/issues/554>`_

--- a/src/main/scala/xitrum/Config.scala
+++ b/src/main/scala/xitrum/Config.scala
@@ -1,6 +1,6 @@
 package xitrum
 
-import java.io.File
+import java.io.{File, FileNotFoundException}
 import java.net.{URL, URLClassLoader}
 import java.nio.charset.Charset
 import java.util.{Map => JMap}
@@ -78,13 +78,13 @@ class HttpsConfig(val config: TConfig) {
   lazy val certChainFile = {
     val path = config.getString("certChainFile")
     val file = new File(path)
-    if (!file.exists) Config.exitOnStartupError("certChainFile specified in xitrum.conf does not exist")
+    if (!file.exists) Config.exitOnStartupError("certChainFile specified in xitrum.conf does not exist", new FileNotFoundException(file.getAbsolutePath))
     file
   }
   lazy val keyFile = {
     val path = config.getString("keyFile")
     val file = new File(path)
-    if (!file.exists) Config.exitOnStartupError("keyFile specified in xitrum.conf does not exist")
+    if (!file.exists) Config.exitOnStartupError("keyFile specified in xitrum.conf does not exist", new FileNotFoundException(file.getAbsolutePath))
     file
   }
 }


### PR DESCRIPTION
This PR is patch for #555 
Log will be like below
```
[WARN] [15-07-29 14:44:04] x.package$: *** For security, change secureKey in config/xitrum.conf to your own! ***
[ERROR] [15-07-29 14:44:07] x.package$: certChainFile specified in xitrum.conf does not exist
java.io.FileNotFoundException: /Users/oshidatakeharu/Project/temp/xitrum-new/target/xitrum/config/_ssl_example.crt
	at xitrum.HttpsConfig.certChainFile$lzycompute(Config.scala:81) [xitrum_2.11.jar:3.24.1-SNAPSHOT]
	at xitrum.HttpsConfig.certChainFile(Config.scala:78) [xitrum_2.11.jar:3.24.1-SNAPSHOT]
	at xitrum.handler.SslChannelInitializer$.<init>(SslChannelInitializer.scala:15) [xitrum_2.11.jar:3.24.1-SNAPSHOT]
	at xitrum.handler.SslChannelInitializer$.<clinit>(SslChannelInitializer.scala) [xitrum_2.11.jar:3.24.1-SNAPSHOT]
	at xitrum.handler.SslChannelInitializer.initChannel(SslChannelInitializer.scala:24) [xitrum_2.11.jar:3.24.1-SNAPSHOT]
	at xitrum.handler.SslChannelInitializer.initChannel(SslChannelInitializer.scala:21) [xitrum_2.11.jar:3.24.1-SNAPSHOT]
	at io.netty.channel.ChannelInitializer.channelRegistered(ChannelInitializer.java:68) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRegistered(AbstractChannelHandlerContext.java:133) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRegistered(AbstractChannelHandlerContext.java:119) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRegistered(DefaultChannelPipeline.java:733) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:450) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$100(AbstractChannel.java:378) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:424) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:356) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:357) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:110) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137) [netty-all-4.0.30.Final.jar:4.0.30.Final]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_25]
[ERROR] [15-07-29 14:44:07] x.package$: Xitrum could not start because of the above error. Xitrum will now stop the current process.
```