### PR TITLE
Add executionTime metric

### DIFF
--- a/src/main/scala/xitrum/handler/AccessLog.scala
+++ b/src/main/scala/xitrum/handler/AccessLog.scala
@@ -57,6 +57,7 @@ object AccessLog {
   // Save last executeTime of each access
   // Map('actionName': [timestamp, execTime])
   private lazy val lastExecTimeMap = MMap[String, Array[Long]]()
+  private final val executionTimeHistogramKey = "executionTime"
 
   private def msgWithTime(className: String, action: Action, beginTimestamp: Long) = {
     val endTimestamp                 = System.currentTimeMillis()
@@ -78,7 +79,13 @@ object AccessLog {
           histograms.get(actionClassName)
         else
           xitrum.Metrics.histogram(actionClassName)
+      val executionTimeHistogram = 
+        if (histograms.containsKey(executionTimeHistogramKey))
+          histograms.get(executionTimeHistogramKey)
+        else
+          xitrum.Metrics.histogram(executionTimeHistogramKey)
       histogram.asInstanceOf[Histogram] += dt
+      executionTimeHistogram.asInstanceOf[Histogram] += dt
       lastExecTimeMap(actionClassName) = Array(System.currentTimeMillis, dt)
     }
 


### PR DESCRIPTION
Added metric that tracks execution time of all actions. This metric is useful when we want monitor whole app with one metric. With this metric we can monitor average performance of node.