### PR TITLE
Annotateable trait

### DIFF
--- a/src/main/scala/xitrum/Action.scala
+++ b/src/main/scala/xitrum/Action.scala
@@ -47,6 +47,7 @@ trait Action extends RequestEnv
   with JsRenderer
   with JsResponder
   with I18n
+  with Annotateable
 {
   /** This is convenient, for example, when you want to get the current action in view templates. */
   implicit val currentAction = Action.this

--- a/src/main/scala/xitrum/Annotateable.scala
+++ b/src/main/scala/xitrum/Annotateable.scala
@@ -1,0 +1,3 @@
+package xitrum
+
+trait Annotateable

--- a/src/main/scala/xitrum/routing/ActionTreeBuilder.scala
+++ b/src/main/scala/xitrum/routing/ActionTreeBuilder.scala
@@ -5,6 +5,7 @@ import scala.collection.mutable.{Map => MMap}
 import scala.reflect.runtime.universe
 
 import xitrum.Action
+import xitrum.Annotateable
 import xitrum.annotation.ActionAnnotations
 
 /**
@@ -64,7 +65,7 @@ private case class ActionTreeBuilder(xitrumVersion: String, parent2Children: Map
     //   modified annotations (if any) can be recollected.
     // * We use class name instead of class, to avoid conflict between different
     //   class loaders.
-    val actionClass   = cl.loadClass(classOf[Action].getName)
+    val annotateableClass   = cl.loadClass(classOf[Annotateable].getName)
     val runtimeMirror = universe.runtimeMirror(cl)
     val cache         = MMap.empty[String, ActionAnnotations]
 
@@ -79,7 +80,7 @@ private case class ActionTreeBuilder(xitrumVersion: String, parent2Children: Map
             // parentClass is null if klass is a trait/interface
             if (parentClass == null) {
               acc
-            } else if (actionClass.isAssignableFrom(parentClass)) {
+            } else if (annotateableClass.isAssignableFrom(parentClass)) {
               val aa = getActionAccumulatedAnnotations(parentClass.getName)
               acc.inherit(aa)
             } else {


### PR DESCRIPTION
now we can do:

``` scala
@Swagger(
  Swagger.LongQuery("id", "ID"))
trait IdQueryParam extends xitrum.Annotateable {
  this: Action =>
  lazy val id = param("id")
  ...
}

@GET("")
@Swagger(
  Swagger.Tags("example"))
class SiteIndex extends DefaultLayout with IdQueryParam {
  override def execute() {
    ...
  }
}
```

and SiteIndex inherit Swagger annotations from IdQueryParam
