### PR TITLE
Swagger documentation for BodyParam and Responses with JSON models generated from case classes by reflections

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=false
+indent_style=space
+indent_size=2
+

--- a/src/main/scala/xitrum/annotation/Swagger.scala
+++ b/src/main/scala/xitrum/annotation/Swagger.scala
@@ -243,7 +243,7 @@ object Swagger {
     * Usage:
     * create some `case class Response(value: String)` for your API response
     * create somewhere type definition `val swagger = Swagger.valueOf[Response]`
-    * use that type definition to document your Swagger API `Swagger.Response(200, "Success", swagger)`
+    * use that type definition to document your Swagger API `Swagger.Response(200, "Success", Some(swagger))`
     */
   def valueOf[T](implicit tag: TypeTag[T]): JsonType = {
     val tpe = tag.tpe

--- a/src/main/scala/xitrum/annotation/Swagger.scala
+++ b/src/main/scala/xitrum/annotation/Swagger.scala
@@ -8,380 +8,255 @@ case class Swagger(swaggerArgs: SwaggerTypes.SwaggerArg*) extends StaticAnnotati
 // Put outside object Swagger so that in IDEs like Eclipse, when typing Swagger<dot>,
 // SwaggerArg won't be shown, only concrete SwaggerArgs are shown.
 object SwaggerTypes {
+  sealed trait SwaggerArg
 
-	sealed trait SwaggerArg
+  sealed trait SwaggerParamArg extends SwaggerArg {
+    def name: String
+    def desc: String
+  }
 
-	sealed trait SwaggerParamArg extends SwaggerArg {
-		def name: String
+  sealed trait SwaggerOptParamArg extends SwaggerParamArg
 
-		def desc: String
-	}
+  sealed trait SwaggerPathParam
+  sealed trait SwaggerQueryParam
+  sealed trait SwaggerHeaderParam
+  sealed trait SwaggerFormParam
+  sealed trait SwaggerBodyParam
 
-	sealed trait SwaggerOptParamArg extends SwaggerParamArg
-
-	sealed trait SwaggerPathParam
-
-	sealed trait SwaggerQueryParam
-
-	sealed trait SwaggerHeaderParam
-
-	sealed trait SwaggerFormParam
-
-	sealed trait SwaggerBodyParam
-
-	sealed trait SwaggerIntParam
-
-	sealed trait SwaggerLongParam
-
-	sealed trait SwaggerFloatParam
-
-	sealed trait SwaggerDoubleParam
-
-	sealed trait SwaggerStringParam
-
-	sealed trait SwaggerByteParam
-
-	sealed trait SwaggerBinaryParam
-
-	sealed trait SwaggerBooleanParam
-
-	sealed trait SwaggerDateParam
-
-	sealed trait SwaggerDateTimeParam
-
-	sealed trait SwaggerPasswordParam
-
-	sealed trait SwaggerFileParam
-
-	sealed trait SwaggerJsonParam
-
+  sealed trait SwaggerIntParam
+  sealed trait SwaggerLongParam
+  sealed trait SwaggerFloatParam
+  sealed trait SwaggerDoubleParam
+  sealed trait SwaggerStringParam
+  sealed trait SwaggerByteParam
+  sealed trait SwaggerBinaryParam
+  sealed trait SwaggerBooleanParam
+  sealed trait SwaggerDateParam
+  sealed trait SwaggerDateTimeParam
+  sealed trait SwaggerPasswordParam
+  sealed trait SwaggerFileParam
+  sealed trait SwaggerJsonParam
 }
 
 /** See: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md */
 object Swagger {
-
-	import SwaggerTypes._
-
-	case class Tags(tags: String*) extends SwaggerArg
-
-	case class Summary(summary: String) extends SwaggerArg
-
-	case class Description(desc: String) extends SwaggerArg
-
-	case class ExternalDocs(url: String, desc: String = "") extends SwaggerArg
-
-	case class OperationId(id: String) extends SwaggerArg
-
-	case class Consumes(contentTypes: String*) extends SwaggerArg
-
-	case class Produces(contentTypes: String*) extends SwaggerArg
-
-	/** Can use this multiple times at an action. */
-	case class Response(code: Int = 0, desc: String, tpeOpt: Option[JsonType] = None) extends SwaggerArg
-
-	case class Schemes(schemes: String*) extends SwaggerArg
-
-	case object Deprecated extends SwaggerArg
-
-	//----------------------------------------------------------------------------
-
-	case class IntPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerIntParam
-
-	case class LongPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerLongParam
-
-	case class FloatPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerFloatParam
-
-	case class DoublePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDoubleParam
-
-	case class StringPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerStringParam
-
-	case class BytePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerByteParam
-
-	case class BinaryPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerBinaryParam
-
-	case class BooleanPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerBooleanParam
-
-	case class DatePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDateParam
-
-	case class DateTimePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDateTimeParam
-
-	case class PasswordPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerPasswordParam
-
-	case class IntQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerIntParam
-
-	case class LongQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerLongParam
-
-	case class FloatQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerFloatParam
-
-	case class DoubleQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDoubleParam
-
-	case class StringQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerStringParam
-
-	case class ByteQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerByteParam
-
-	case class BinaryQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerBinaryParam
-
-	case class BooleanQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerBooleanParam
-
-	case class DateQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDateParam
-
-	case class DateTimeQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDateTimeParam
-
-	case class PasswordQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerPasswordParam
-
-	case class IntHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerIntParam
-
-	case class LongHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerLongParam
-
-	case class FloatHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerFloatParam
-
-	case class DoubleHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDoubleParam
-
-	case class StringHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerStringParam
-
-	case class ByteHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerByteParam
-
-	case class BinaryHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerBinaryParam
-
-	case class BooleanHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerBooleanParam
-
-	case class DateHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDateParam
-
-	case class DateTimeHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDateTimeParam
-
-	case class PasswordHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerPasswordParam
-
-	case class IntForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerIntParam
-
-	case class LongForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerLongParam
-
-	case class FloatForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerFloatParam
-
-	case class DoubleForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDoubleParam
-
-	case class StringForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerStringParam
-
-	case class ByteForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerByteParam
-
-	case class BinaryForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerBinaryParam
-
-	case class BooleanForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerBooleanParam
-
-	case class DateForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDateParam
-
-	case class DateTimeForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDateTimeParam
-
-	case class PasswordForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerPasswordParam
-
-	case class FileForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerFileParam
-
-	case class IntBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerIntParam
-
-	case class LongBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerLongParam
-
-	case class FloatBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerFloatParam
-
-	case class DoubleBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDoubleParam
-
-	case class StringBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerStringParam
-
-	case class ByteBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerByteParam
-
-	case class BinaryBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerBinaryParam
-
-	case class BooleanBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerBooleanParam
-
-	case class DateBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateParam
-
-	case class DateTimeBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateTimeParam
-
-	case class PasswordBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerPasswordParam
-
-	case class JsonBody(name: String, desc: String = "", tpe: JsonType) extends SwaggerParamArg with SwaggerBodyParam with SwaggerJsonParam
-
-	//----------------------------------------------------------------------------
-
-	case class OptIntPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerIntParam
-
-	case class OptLongPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerLongParam
-
-	case class OptFloatPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerFloatParam
-
-	case class OptDoublePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDoubleParam
-
-	case class OptStringPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerStringParam
-
-	case class OptBytePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerByteParam
-
-	case class OptBinaryPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerBinaryParam
-
-	case class OptBooleanPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerBooleanParam
-
-	case class OptDatePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDateParam
-
-	case class OptDateTimePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDateTimeParam
-
-	case class OptPasswordPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerPasswordParam
-
-	case class OptIntQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerIntParam
-
-	case class OptLongQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerLongParam
-
-	case class OptFloatQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerFloatParam
-
-	case class OptDoubleQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDoubleParam
-
-	case class OptStringQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerStringParam
-
-	case class OptByteQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerByteParam
-
-	case class OptBinaryQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerBinaryParam
-
-	case class OptBooleanQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerBooleanParam
-
-	case class OptDateQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDateParam
-
-	case class OptDateTimeQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDateTimeParam
-
-	case class OptPasswordQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerPasswordParam
-
-	case class OptIntHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerIntParam
-
-	case class OptLongHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerLongParam
-
-	case class OptFloatHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerFloatParam
-
-	case class OptDoubleHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDoubleParam
-
-	case class OptStringHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerStringParam
-
-	case class OptByteHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerByteParam
-
-	case class OptBinaryHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerBinaryParam
-
-	case class OptBooleanHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerBooleanParam
-
-	case class OptDateHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDateParam
-
-	case class OptDateTimeHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDateTimeParam
-
-	case class OptPasswordHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerPasswordParam
-
-	case class OptIntForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerIntParam
-
-	case class OptLongForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerLongParam
-
-	case class OptFloatForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerFloatParam
-
-	case class OptDoubleForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDoubleParam
-
-	case class OptStringForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerStringParam
-
-	case class OptByteForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerByteParam
-
-	case class OptBinaryForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerBinaryParam
-
-	case class OptBooleanForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerBooleanParam
-
-	case class OptDateForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDateParam
-
-	case class OptDateTimeForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDateTimeParam
-
-	case class OptPasswordForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerPasswordParam
-
-	case class OptFileForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerFileParam
-
-	case class OptIntBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerIntParam
-
-	case class OptLongBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerLongParam
-
-	case class OptFloatBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerFloatParam
-
-	case class OptDoubleBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDoubleParam
-
-	case class OptStringBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerStringParam
-
-	case class OptByteBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerByteParam
-
-	case class OptBinaryBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerBinaryParam
-
-	case class OptBooleanBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerBooleanParam
-
-	case class OptDateBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateParam
-
-	case class OptDateTimeBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateTimeParam
-
-	case class OptPasswordBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerPasswordParam
-
-	// Types definitions
-
-	/**
-		* Structure for building object fields documentation
-		* @param name field name
-		* @param tpe field type
-		* @param isRequired_? if true means that field is required
-		*/
-	case class JsonField(name: String, tpe: JsonType, isRequired_? : Boolean = false)
-
-	/**
-		* Structure for building object types documentation
-		* @param name type name (actual for `tpe` == "object" only)
-		* @param tpe type in Swagger terms @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
-		* @param format additional Swagger type definition
-		* @param isArray_? true is marking the type as array of `tpe` items
-		* @param fields list of `object` fields (actual for `tpe` == "object" only)
-		*/
-	case class JsonType(name: Option[String], tpe: String, format: String = "", var isArray_? : Boolean = false, var fields: Seq[JsonField] = Seq()) {
-
-		def isArray(value: Boolean): JsonType = {
-			isArray_? = value
-			this
-		}
-	}
-
-	object JsonType {
-	 	object tpe {
-		  val integer = "integer"
-		  val number = "number"
-		  val string = "string"
-		  val boolean = "boolean"
-		  val obj = "object"
-		  val file = "file"
-	  }
-		object fmt {
-			val none = ""
-			val int32 = "int32"
-			val int64 = "int64"
-			val float = "float"
-			val double = "double"
-			val dateTime = "date-time"
-			val byte = "byte"
-			val binary = "binary"
-			val date = "date"
-			val password = "password"
-		}
-	}
-
-	/**
-		* Builds the Swagger type definition structure for documenting API requests/responses represented by single objects
-		*
-		* Usage:
-		* create some `case class Response(value: String)` for your API response
-		* create somewhere type definition `val swagger = Swagger.valueOf[Response]`
-		* use that type definition to document your Swagger API `Swagger.Response(200, "Success", swagger)`
-		*/
-	def valueOf[T](implicit tag: TypeTag[T]): JsonType = {
-		val tpe = tag.tpe
-		assert(tpe.typeSymbol != symbolOf[Option[_]], "Root types can not be optional, optional parameters should be implemented with Opt version of annotations")
-		assert(!SwaggerReflection.isArrayType_?(tpe), "Root types should not be of collection types, to specify the array type use `arrayOf` method instead")
-		SwaggerReflection.reflect(tpe)
-	}
-
-	/**
-		* Builds the Swagger type definition structure for documenting API requests/responses represented by arrays of specific object type
-		*/
-	def arrayOf[T](implicit tag: TypeTag[T]): JsonType = {
-		valueOf(tag).isArray(true)
-	}
+  import SwaggerTypes._
+
+  case class Tags(tags: String*) extends SwaggerArg
+  case class Summary(summary: String) extends SwaggerArg
+  case class Description(desc: String) extends SwaggerArg
+  case class ExternalDocs(url: String, desc: String = "") extends SwaggerArg
+  case class OperationId(id: String) extends SwaggerArg
+  case class Consumes(contentTypes: String*) extends SwaggerArg
+  case class Produces(contentTypes: String*) extends SwaggerArg
+
+  /** Can use this multiple times at an action. */
+  case class Response(code: Int = 0, desc: String, tpeOpt: Option[JsonType] = None) extends SwaggerArg
+
+  case class Schemes(schemes: String*) extends SwaggerArg
+  case object Deprecated extends SwaggerArg
+
+  //----------------------------------------------------------------------------
+
+  case class IntPath     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerIntParam
+  case class LongPath    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerLongParam
+  case class FloatPath   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerFloatParam
+  case class DoublePath  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDoubleParam
+  case class StringPath  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerStringParam
+  case class BytePath    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerByteParam
+  case class BinaryPath  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerBinaryParam
+  case class BooleanPath (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerBooleanParam
+  case class DatePath    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDateParam
+  case class DateTimePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDateTimeParam
+  case class PasswordPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerPasswordParam
+
+  case class IntQuery     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerIntParam
+  case class LongQuery    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerLongParam
+  case class FloatQuery   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerFloatParam
+  case class DoubleQuery  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDoubleParam
+  case class StringQuery  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerStringParam
+  case class ByteQuery    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerByteParam
+  case class BinaryQuery  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerBinaryParam
+  case class BooleanQuery (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerBooleanParam
+  case class DateQuery    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDateParam
+  case class DateTimeQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDateTimeParam
+  case class PasswordQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerPasswordParam
+
+  case class IntHeader     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerIntParam
+  case class LongHeader    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerLongParam
+  case class FloatHeader   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerFloatParam
+  case class DoubleHeader  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDoubleParam
+  case class StringHeader  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerStringParam
+  case class ByteHeader    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerByteParam
+  case class BinaryHeader  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerBinaryParam
+  case class BooleanHeader (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerBooleanParam
+  case class DateHeader    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDateParam
+  case class DateTimeHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDateTimeParam
+  case class PasswordHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerPasswordParam
+
+  case class IntForm     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerIntParam
+  case class LongForm    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerLongParam
+  case class FloatForm   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerFloatParam
+  case class DoubleForm  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDoubleParam
+  case class StringForm  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerStringParam
+  case class ByteForm    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerByteParam
+  case class BinaryForm  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerBinaryParam
+  case class BooleanForm (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerBooleanParam
+  case class DateForm    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDateParam
+  case class DateTimeForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDateTimeParam
+  case class PasswordForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerPasswordParam
+  case class FileForm    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerFileParam
+
+  case class IntBody     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerIntParam
+  case class LongBody    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerLongParam
+  case class FloatBody   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerFloatParam
+  case class DoubleBody  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDoubleParam
+  case class StringBody  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerStringParam
+  case class ByteBody    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerByteParam
+  case class BinaryBody  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerBinaryParam
+  case class BooleanBody (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerBooleanParam
+  case class DateBody    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateParam
+  case class DateTimeBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateTimeParam
+  case class PasswordBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerPasswordParam
+  case class JsonBody    (name: String, desc: String = "", tpe: JsonType) extends SwaggerParamArg with SwaggerBodyParam with SwaggerJsonParam
+
+  //----------------------------------------------------------------------------
+
+  case class OptIntPath     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerIntParam
+  case class OptLongPath    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerLongParam
+  case class OptFloatPath   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerFloatParam
+  case class OptDoublePath  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDoubleParam
+  case class OptStringPath  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerStringParam
+  case class OptBytePath    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerByteParam
+  case class OptBinaryPath  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerBinaryParam
+  case class OptBooleanPath (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerBooleanParam
+  case class OptDatePath    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDateParam
+  case class OptDateTimePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDateTimeParam
+  case class OptPasswordPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerPasswordParam
+
+  case class OptIntQuery     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerIntParam
+  case class OptLongQuery    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerLongParam
+  case class OptFloatQuery   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerFloatParam
+  case class OptDoubleQuery  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDoubleParam
+  case class OptStringQuery  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerStringParam
+  case class OptByteQuery    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerByteParam
+  case class OptBinaryQuery  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerBinaryParam
+  case class OptBooleanQuery (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerBooleanParam
+  case class OptDateQuery    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDateParam
+  case class OptDateTimeQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDateTimeParam
+  case class OptPasswordQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerPasswordParam
+
+  case class OptIntHeader     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerIntParam
+  case class OptLongHeader    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerLongParam
+  case class OptFloatHeader   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerFloatParam
+  case class OptDoubleHeader  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDoubleParam
+  case class OptStringHeader  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerStringParam
+  case class OptByteHeader    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerByteParam
+  case class OptBinaryHeader  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerBinaryParam
+  case class OptBooleanHeader (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerBooleanParam
+  case class OptDateHeader    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDateParam
+  case class OptDateTimeHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDateTimeParam
+  case class OptPasswordHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerPasswordParam
+
+  case class OptIntForm     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerIntParam
+  case class OptLongForm    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerLongParam
+  case class OptFloatForm   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerFloatParam
+  case class OptDoubleForm  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDoubleParam
+  case class OptStringForm  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerStringParam
+  case class OptByteForm    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerByteParam
+  case class OptBinaryForm  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerBinaryParam
+  case class OptBooleanForm (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerBooleanParam
+  case class OptDateForm    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDateParam
+  case class OptDateTimeForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDateTimeParam
+  case class OptPasswordForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerPasswordParam
+  case class OptFileForm    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerFileParam
+
+  case class OptIntBody     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerIntParam
+  case class OptLongBody    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerLongParam
+  case class OptFloatBody   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerFloatParam
+  case class OptDoubleBody  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDoubleParam
+  case class OptStringBody  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerStringParam
+  case class OptByteBody    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerByteParam
+  case class OptBinaryBody  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerBinaryParam
+  case class OptBooleanBody (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerBooleanParam
+  case class OptDateBody    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateParam
+  case class OptDateTimeBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateTimeParam
+  case class OptPasswordBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerPasswordParam
+
+  // Types definitions
+
+  /**
+    * Structure for building object fields documentation
+    *
+    * @param name         field name
+    * @param tpe          field type
+    * @param isRequired_? if true means that field is required
+    */
+  case class JsonField(name: String, tpe: JsonType, isRequired_? : Boolean = false)
+
+  /**
+    * Structure for building object types documentation
+    *
+    * @param name      type name (actual for `tpe` == "object" only)
+    * @param tpe       type in Swagger terms @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+    * @param format    additional Swagger type definition
+    * @param isArray_? true is marking the type as array of `tpe` items
+    * @param fields    list of `object` fields (actual for `tpe` == "object" only)
+    */
+  case class JsonType(name: Option[String], tpe: String, format: String = "", var isArray_? : Boolean = false, var fields: Seq[JsonField] = Seq()) {
+
+    def isArray(value: Boolean): JsonType = {
+      isArray_? = value
+      this
+    }
+  }
+
+  object JsonType {
+
+    object tpe {
+      val integer = "integer"
+      val number = "number"
+      val string = "string"
+      val boolean = "boolean"
+      val obj = "object"
+      val file = "file"
+    }
+
+    object fmt {
+      val none = ""
+      val int32 = "int32"
+      val int64 = "int64"
+      val float = "float"
+      val double = "double"
+      val dateTime = "date-time"
+      val byte = "byte"
+      val binary = "binary"
+      val date = "date"
+      val password = "password"
+    }
+
+  }
+
+  /**
+    * Builds the Swagger type definition structure for documenting API requests/responses represented by single objects
+    *
+    * Usage:
+    * create some `case class Response(value: String)` for your API response
+    * create somewhere type definition `val swagger = Swagger.valueOf[Response]`
+    * use that type definition to document your Swagger API `Swagger.Response(200, "Success", swagger)`
+    */
+  def valueOf[T](implicit tag: TypeTag[T]): JsonType = {
+    val tpe = tag.tpe
+    assert(tpe.typeSymbol != symbolOf[Option[_]], "Root types can not be optional, optional parameters should be implemented with Opt version of annotations")
+    assert(!SwaggerReflection.isArrayType_?(tpe), "Root types should not be of collection types, to specify the array type use `arrayOf` method instead")
+    SwaggerReflection.reflect(tpe)
+  }
+
+  /**
+    * Builds the Swagger type definition structure for documenting API requests/responses represented by arrays of specific object type
+    */
+  def arrayOf[T](implicit tag: TypeTag[T]): JsonType = {
+    valueOf(tag).isArray(true)
+  }
 
 }

--- a/src/main/scala/xitrum/annotation/Swagger.scala
+++ b/src/main/scala/xitrum/annotation/Swagger.scala
@@ -1,5 +1,6 @@
 package xitrum.annotation
 
+import scala.reflect.runtime.universe.{TypeTag, symbolOf}
 import scala.annotation.StaticAnnotation
 
 case class Swagger(swaggerArgs: SwaggerTypes.SwaggerArg*) extends StaticAnnotation
@@ -7,177 +8,380 @@ case class Swagger(swaggerArgs: SwaggerTypes.SwaggerArg*) extends StaticAnnotati
 // Put outside object Swagger so that in IDEs like Eclipse, when typing Swagger<dot>,
 // SwaggerArg won't be shown, only concrete SwaggerArgs are shown.
 object SwaggerTypes {
-  sealed trait SwaggerArg
 
-  sealed trait SwaggerParamArg extends SwaggerArg {
-    def name: String
-    def desc: String
-  }
+	sealed trait SwaggerArg
 
-  sealed trait SwaggerOptParamArg extends SwaggerParamArg
+	sealed trait SwaggerParamArg extends SwaggerArg {
+		def name: String
 
-  sealed trait SwaggerPathParam
-  sealed trait SwaggerQueryParam
-  sealed trait SwaggerHeaderParam
-  sealed trait SwaggerFormParam
-  sealed trait SwaggerBodyParam
+		def desc: String
+	}
 
-  sealed trait SwaggerIntParam
-  sealed trait SwaggerLongParam
-  sealed trait SwaggerFloatParam
-  sealed trait SwaggerDoubleParam
-  sealed trait SwaggerStringParam
-  sealed trait SwaggerByteParam
-  sealed trait SwaggerBinaryParam
-  sealed trait SwaggerBooleanParam
-  sealed trait SwaggerDateParam
-  sealed trait SwaggerDateTimeParam
-  sealed trait SwaggerPasswordParam
-  sealed trait SwaggerFileParam
+	sealed trait SwaggerOptParamArg extends SwaggerParamArg
+
+	sealed trait SwaggerPathParam
+
+	sealed trait SwaggerQueryParam
+
+	sealed trait SwaggerHeaderParam
+
+	sealed trait SwaggerFormParam
+
+	sealed trait SwaggerBodyParam
+
+	sealed trait SwaggerIntParam
+
+	sealed trait SwaggerLongParam
+
+	sealed trait SwaggerFloatParam
+
+	sealed trait SwaggerDoubleParam
+
+	sealed trait SwaggerStringParam
+
+	sealed trait SwaggerByteParam
+
+	sealed trait SwaggerBinaryParam
+
+	sealed trait SwaggerBooleanParam
+
+	sealed trait SwaggerDateParam
+
+	sealed trait SwaggerDateTimeParam
+
+	sealed trait SwaggerPasswordParam
+
+	sealed trait SwaggerFileParam
+
+	sealed trait SwaggerJsonParam
+
 }
 
 /** See: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md */
 object Swagger {
-  import SwaggerTypes._
 
-  case class Tags(tags: String*) extends SwaggerArg
-  case class Summary(summary: String) extends SwaggerArg
-  case class Description(desc: String) extends SwaggerArg
-  case class ExternalDocs(url: String, desc: String = "") extends SwaggerArg
-  case class OperationId(id: String) extends SwaggerArg
+	import SwaggerTypes._
 
-  case class Consumes(contentTypes: String*) extends SwaggerArg
-  case class Produces(contentTypes: String*) extends SwaggerArg
+	case class Tags(tags: String*) extends SwaggerArg
 
-  /** Can use this multiple times at an action. */
-  case class Response(code: Int = 0, desc: String) extends SwaggerArg
+	case class Summary(summary: String) extends SwaggerArg
 
-  case class Schemes(schemes: String*) extends SwaggerArg
-  case object Deprecated extends SwaggerArg
+	case class Description(desc: String) extends SwaggerArg
 
-  //----------------------------------------------------------------------------
+	case class ExternalDocs(url: String, desc: String = "") extends SwaggerArg
 
-  case class IntPath     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerIntParam
-  case class LongPath    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerLongParam
-  case class FloatPath   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerFloatParam
-  case class DoublePath  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDoubleParam
-  case class StringPath  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerStringParam
-  case class BytePath    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerByteParam
-  case class BinaryPath  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerBinaryParam
-  case class BooleanPath (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerBooleanParam
-  case class DatePath    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDateParam
-  case class DateTimePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDateTimeParam
-  case class PasswordPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerPasswordParam
+	case class OperationId(id: String) extends SwaggerArg
 
-  case class IntQuery     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerIntParam
-  case class LongQuery    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerLongParam
-  case class FloatQuery   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerFloatParam
-  case class DoubleQuery  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDoubleParam
-  case class StringQuery  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerStringParam
-  case class ByteQuery    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerByteParam
-  case class BinaryQuery  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerBinaryParam
-  case class BooleanQuery (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerBooleanParam
-  case class DateQuery    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDateParam
-  case class DateTimeQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDateTimeParam
-  case class PasswordQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerPasswordParam
+	case class Consumes(contentTypes: String*) extends SwaggerArg
 
-  case class IntHeader     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerIntParam
-  case class LongHeader    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerLongParam
-  case class FloatHeader   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerFloatParam
-  case class DoubleHeader  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDoubleParam
-  case class StringHeader  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerStringParam
-  case class ByteHeader    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerByteParam
-  case class BinaryHeader  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerBinaryParam
-  case class BooleanHeader (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerBooleanParam
-  case class DateHeader    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDateParam
-  case class DateTimeHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDateTimeParam
-  case class PasswordHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerPasswordParam
+	case class Produces(contentTypes: String*) extends SwaggerArg
 
-  case class IntForm     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerIntParam
-  case class LongForm    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerLongParam
-  case class FloatForm   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerFloatParam
-  case class DoubleForm  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDoubleParam
-  case class StringForm  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerStringParam
-  case class ByteForm    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerByteParam
-  case class BinaryForm  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerBinaryParam
-  case class BooleanForm (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerBooleanParam
-  case class DateForm    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDateParam
-  case class DateTimeForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDateTimeParam
-  case class PasswordForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerPasswordParam
-  case class FileForm    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerFileParam
+	/** Can use this multiple times at an action. */
+	case class Response(code: Int = 0, desc: String, tpeOpt: Option[JsonType] = None) extends SwaggerArg
 
-  case class IntBody     (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerIntParam
-  case class LongBody    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerLongParam
-  case class FloatBody   (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerFloatParam
-  case class DoubleBody  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDoubleParam
-  case class StringBody  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerStringParam
-  case class ByteBody    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerByteParam
-  case class BinaryBody  (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerBinaryParam
-  case class BooleanBody (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerBooleanParam
-  case class DateBody    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateParam
-  case class DateTimeBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateTimeParam
-  case class PasswordBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerPasswordParam
+	case class Schemes(schemes: String*) extends SwaggerArg
 
-  //----------------------------------------------------------------------------
+	case object Deprecated extends SwaggerArg
 
-  case class OptIntPath     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerIntParam
-  case class OptLongPath    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerLongParam
-  case class OptFloatPath   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerFloatParam
-  case class OptDoublePath  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDoubleParam
-  case class OptStringPath  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerStringParam
-  case class OptBytePath    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerByteParam
-  case class OptBinaryPath  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerBinaryParam
-  case class OptBooleanPath (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerBooleanParam
-  case class OptDatePath    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDateParam
-  case class OptDateTimePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDateTimeParam
-  case class OptPasswordPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerPasswordParam
+	//----------------------------------------------------------------------------
 
-  case class OptIntQuery     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerIntParam
-  case class OptLongQuery    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerLongParam
-  case class OptFloatQuery   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerFloatParam
-  case class OptDoubleQuery  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDoubleParam
-  case class OptStringQuery  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerStringParam
-  case class OptByteQuery    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerByteParam
-  case class OptBinaryQuery  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerBinaryParam
-  case class OptBooleanQuery (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerBooleanParam
-  case class OptDateQuery    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDateParam
-  case class OptDateTimeQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDateTimeParam
-  case class OptPasswordQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerPasswordParam
+	case class IntPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerIntParam
 
-  case class OptIntHeader     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerIntParam
-  case class OptLongHeader    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerLongParam
-  case class OptFloatHeader   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerFloatParam
-  case class OptDoubleHeader  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDoubleParam
-  case class OptStringHeader  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerStringParam
-  case class OptByteHeader    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerByteParam
-  case class OptBinaryHeader  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerBinaryParam
-  case class OptBooleanHeader (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerBooleanParam
-  case class OptDateHeader    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDateParam
-  case class OptDateTimeHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDateTimeParam
-  case class OptPasswordHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerPasswordParam
+	case class LongPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerLongParam
 
-  case class OptIntForm     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerIntParam
-  case class OptLongForm    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerLongParam
-  case class OptFloatForm   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerFloatParam
-  case class OptDoubleForm  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDoubleParam
-  case class OptStringForm  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerStringParam
-  case class OptByteForm    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerByteParam
-  case class OptBinaryForm  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerBinaryParam
-  case class OptBooleanForm (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerBooleanParam
-  case class OptDateForm    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDateParam
-  case class OptDateTimeForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDateTimeParam
-  case class OptPasswordForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerPasswordParam
-  case class OptFileForm    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerFileParam
+	case class FloatPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerFloatParam
 
-  case class OptIntBody     (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerIntParam
-  case class OptLongBody    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerLongParam
-  case class OptFloatBody   (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerFloatParam
-  case class OptDoubleBody  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDoubleParam
-  case class OptStringBody  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerStringParam
-  case class OptByteBody    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerByteParam
-  case class OptBinaryBody  (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerBinaryParam
-  case class OptBooleanBody (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerBooleanParam
-  case class OptDateBody    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateParam
-  case class OptDateTimeBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateTimeParam
-  case class OptPasswordBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerPasswordParam
+	case class DoublePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDoubleParam
+
+	case class StringPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerStringParam
+
+	case class BytePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerByteParam
+
+	case class BinaryPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerBinaryParam
+
+	case class BooleanPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerBooleanParam
+
+	case class DatePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDateParam
+
+	case class DateTimePath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerDateTimeParam
+
+	case class PasswordPath(name: String, desc: String = "") extends SwaggerParamArg with SwaggerPathParam with SwaggerPasswordParam
+
+	case class IntQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerIntParam
+
+	case class LongQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerLongParam
+
+	case class FloatQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerFloatParam
+
+	case class DoubleQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDoubleParam
+
+	case class StringQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerStringParam
+
+	case class ByteQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerByteParam
+
+	case class BinaryQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerBinaryParam
+
+	case class BooleanQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerBooleanParam
+
+	case class DateQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDateParam
+
+	case class DateTimeQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerDateTimeParam
+
+	case class PasswordQuery(name: String, desc: String = "") extends SwaggerParamArg with SwaggerQueryParam with SwaggerPasswordParam
+
+	case class IntHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerIntParam
+
+	case class LongHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerLongParam
+
+	case class FloatHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerFloatParam
+
+	case class DoubleHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDoubleParam
+
+	case class StringHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerStringParam
+
+	case class ByteHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerByteParam
+
+	case class BinaryHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerBinaryParam
+
+	case class BooleanHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerBooleanParam
+
+	case class DateHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDateParam
+
+	case class DateTimeHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerDateTimeParam
+
+	case class PasswordHeader(name: String, desc: String = "") extends SwaggerParamArg with SwaggerHeaderParam with SwaggerPasswordParam
+
+	case class IntForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerIntParam
+
+	case class LongForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerLongParam
+
+	case class FloatForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerFloatParam
+
+	case class DoubleForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDoubleParam
+
+	case class StringForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerStringParam
+
+	case class ByteForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerByteParam
+
+	case class BinaryForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerBinaryParam
+
+	case class BooleanForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerBooleanParam
+
+	case class DateForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDateParam
+
+	case class DateTimeForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerDateTimeParam
+
+	case class PasswordForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerPasswordParam
+
+	case class FileForm(name: String, desc: String = "") extends SwaggerParamArg with SwaggerFormParam with SwaggerFileParam
+
+	case class IntBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerIntParam
+
+	case class LongBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerLongParam
+
+	case class FloatBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerFloatParam
+
+	case class DoubleBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDoubleParam
+
+	case class StringBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerStringParam
+
+	case class ByteBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerByteParam
+
+	case class BinaryBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerBinaryParam
+
+	case class BooleanBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerBooleanParam
+
+	case class DateBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateParam
+
+	case class DateTimeBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateTimeParam
+
+	case class PasswordBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerPasswordParam
+
+	case class JsonBody(name: String, desc: String = "", tpe: JsonType) extends SwaggerParamArg with SwaggerBodyParam with SwaggerJsonParam
+
+	//----------------------------------------------------------------------------
+
+	case class OptIntPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerIntParam
+
+	case class OptLongPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerLongParam
+
+	case class OptFloatPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerFloatParam
+
+	case class OptDoublePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDoubleParam
+
+	case class OptStringPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerStringParam
+
+	case class OptBytePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerByteParam
+
+	case class OptBinaryPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerBinaryParam
+
+	case class OptBooleanPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerBooleanParam
+
+	case class OptDatePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDateParam
+
+	case class OptDateTimePath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerDateTimeParam
+
+	case class OptPasswordPath(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerPathParam with SwaggerPasswordParam
+
+	case class OptIntQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerIntParam
+
+	case class OptLongQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerLongParam
+
+	case class OptFloatQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerFloatParam
+
+	case class OptDoubleQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDoubleParam
+
+	case class OptStringQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerStringParam
+
+	case class OptByteQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerByteParam
+
+	case class OptBinaryQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerBinaryParam
+
+	case class OptBooleanQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerBooleanParam
+
+	case class OptDateQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDateParam
+
+	case class OptDateTimeQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerDateTimeParam
+
+	case class OptPasswordQuery(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerQueryParam with SwaggerPasswordParam
+
+	case class OptIntHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerIntParam
+
+	case class OptLongHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerLongParam
+
+	case class OptFloatHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerFloatParam
+
+	case class OptDoubleHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDoubleParam
+
+	case class OptStringHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerStringParam
+
+	case class OptByteHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerByteParam
+
+	case class OptBinaryHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerBinaryParam
+
+	case class OptBooleanHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerBooleanParam
+
+	case class OptDateHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDateParam
+
+	case class OptDateTimeHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerDateTimeParam
+
+	case class OptPasswordHeader(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerHeaderParam with SwaggerPasswordParam
+
+	case class OptIntForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerIntParam
+
+	case class OptLongForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerLongParam
+
+	case class OptFloatForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerFloatParam
+
+	case class OptDoubleForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDoubleParam
+
+	case class OptStringForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerStringParam
+
+	case class OptByteForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerByteParam
+
+	case class OptBinaryForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerBinaryParam
+
+	case class OptBooleanForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerBooleanParam
+
+	case class OptDateForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDateParam
+
+	case class OptDateTimeForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerDateTimeParam
+
+	case class OptPasswordForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerPasswordParam
+
+	case class OptFileForm(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerFormParam with SwaggerFileParam
+
+	case class OptIntBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerIntParam
+
+	case class OptLongBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerLongParam
+
+	case class OptFloatBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerFloatParam
+
+	case class OptDoubleBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDoubleParam
+
+	case class OptStringBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerStringParam
+
+	case class OptByteBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerByteParam
+
+	case class OptBinaryBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerBinaryParam
+
+	case class OptBooleanBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerBooleanParam
+
+	case class OptDateBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateParam
+
+	case class OptDateTimeBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateTimeParam
+
+	case class OptPasswordBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerPasswordParam
+
+	// Types definitions
+
+	/**
+		* Structure for building object fields documentation
+		* @param name field name
+		* @param tpe field type
+		* @param isRequired_? if true means that field is required
+		*/
+	case class JsonField(name: String, tpe: JsonType, isRequired_? : Boolean = false)
+
+	/**
+		* Structure for building object types documentation
+		* @param name type name (actual for `tpe` == "object" only)
+		* @param tpe type in Swagger terms @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+		* @param format additional Swagger type definition
+		* @param isArray_? true is marking the type as array of `tpe` items
+		* @param fields list of `object` fields (actual for `tpe` == "object" only)
+		*/
+	case class JsonType(name: Option[String], tpe: String, format: String = "", var isArray_? : Boolean = false, var fields: Seq[JsonField] = Seq()) {
+
+		def isArray(value: Boolean): JsonType = {
+			isArray_? = value
+			this
+		}
+	}
+
+	object JsonType {
+	 	object tpe {
+		  val integer = "integer"
+		  val number = "number"
+		  val string = "string"
+		  val boolean = "boolean"
+		  val obj = "object"
+		  val file = "file"
+	  }
+		object fmt {
+			val none = ""
+			val int32 = "int32"
+			val int64 = "int64"
+			val float = "float"
+			val double = "double"
+			val dateTime = "date-time"
+			val byte = "byte"
+			val binary = "binary"
+			val date = "date"
+			val password = "password"
+		}
+	}
+
+	/**
+		* Builds the Swagger type definition structure for documenting API requests/responses represented by single objects
+		*
+		* Usage:
+		* create some `case class Response(value: String)` for your API response
+		* create somewhere type definition `val swagger = Swagger.valueOf[Response]`
+		* use that type definition to document your Swagger API `Swagger.Response(200, "Success", swagger)`
+		*/
+	def valueOf[T](implicit tag: TypeTag[T]): JsonType = {
+		val tpe = tag.tpe
+		assert(tpe.typeSymbol != symbolOf[Option[_]], "Root types can not be optional, optional parameters should be implemented with Opt version of annotations")
+		assert(!SwaggerReflection.isArrayType_?(tpe), "Root types should not be of collection types, to specify the array type use `arrayOf` method instead")
+		SwaggerReflection.reflect(tpe)
+	}
+
+	/**
+		* Builds the Swagger type definition structure for documenting API requests/responses represented by arrays of specific object type
+		*/
+	def arrayOf[T](implicit tag: TypeTag[T]): JsonType = {
+		valueOf(tag).isArray(true)
+	}
+
 }

--- a/src/main/scala/xitrum/annotation/SwaggerReflection.scala
+++ b/src/main/scala/xitrum/annotation/SwaggerReflection.scala
@@ -3,53 +3,53 @@ package xitrum.annotation
 import scala.reflect.runtime.universe._
 
 /**
-	* Utility functions to reflect scala case classes to structure that can be rendered to Swagger documentation
-	* User: smeagol74
-	* Date: 09.08.17
-	* Time: 0:02
-	*/
+  * Utility functions to reflect scala case classes to structure that can be rendered to Swagger documentation
+  * User: smeagol74
+  * Date: 09.08.17
+  * Time: 0:02
+  */
 object SwaggerReflection {
 
-	private val _arraySymbols = Set[Name](
-		symbolOf[Seq[_]].name,
-		symbolOf[Set[_]].name,
-		symbolOf[List[_]].name,
-		symbolOf[Array[_]].name
-	)
+  private val _arraySymbols = Set[Name](
+    symbolOf[Seq[_]].name,
+    symbolOf[Set[_]].name,
+    symbolOf[List[_]].name,
+    symbolOf[Array[_]].name
+  )
 
-	def isArrayType_?(tpe: Type): Boolean = _arraySymbols.contains(tpe.typeSymbol.name)
+  def isArrayType_?(tpe: Type): Boolean = _arraySymbols.contains(tpe.typeSymbol.name)
 
 
-	def _reflectField(fld: TermSymbol): Swagger.JsonField = {
-		val retType = fld.asMethod.returnType
-		val isRequired = retType.typeSymbol != symbolOf[Option[_]]
-		val tpe = if (isRequired) retType else retType.typeArgs.head
-		Swagger.JsonField(fld.name.toString, reflect(tpe), isRequired)
-	}
+  def _reflectField(fld: TermSymbol): Swagger.JsonField = {
+    val retType = fld.asMethod.returnType
+    val isRequired = retType.typeSymbol != symbolOf[Option[_]]
+    val tpe = if (isRequired) retType else retType.typeArgs.head
+    Swagger.JsonField(fld.name.toString, reflect(tpe), isRequired)
+  }
 
-	def _reflectTypeFormat(tpe: Type): (Option[String], String, String) = tpe.typeSymbol match {
-		case t if t == definitions.IntClass => (None, Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32)
-		case t if t == definitions.LongClass => (None, Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64)
-		case t if t == definitions.FloatClass => (None, Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float)
-		case t if t == definitions.DoubleClass => (None, Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double)
-		case t if t == definitions.StringClass => (None, Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none)
-		case t if t == definitions.BooleanClass => (None, Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none)
-		case t if t == symbolOf[java.util.Date] => (None, Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime)
-		case _ =>
-			var pack = tpe.typeSymbol.owner
-			while (!pack.isPackage)
-				pack = pack.owner
-			(Some(tpe.typeSymbol.fullName.toString.substring(pack.fullName.length + 1)), Swagger.JsonType.tpe.obj, Swagger.JsonType.fmt.none)
-	}
+  def _reflectTypeFormat(tpe: Type): (Option[String], String, String) = tpe.typeSymbol match {
+    case t if t == definitions.IntClass => (None, Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32)
+    case t if t == definitions.LongClass => (None, Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64)
+    case t if t == definitions.FloatClass => (None, Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float)
+    case t if t == definitions.DoubleClass => (None, Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double)
+    case t if t == definitions.StringClass => (None, Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none)
+    case t if t == definitions.BooleanClass => (None, Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none)
+    case t if t == symbolOf[java.util.Date] => (None, Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime)
+    case _ =>
+      var pack = tpe.typeSymbol.owner
+      while (!pack.isPackage)
+        pack = pack.owner
+      (Some(tpe.typeSymbol.fullName.toString.substring(pack.fullName.length + 1)), Swagger.JsonType.tpe.obj, Swagger.JsonType.fmt.none)
+  }
 
-	def reflect(tpe: Type): Swagger.JsonType = {
-		val isArrayType = isArrayType_?(tpe)
-		val tip = if (isArrayType) tpe.typeArgs.head else tpe
-		val fields = tip.decls.filter(_.isPublic)
-			.filter(_.isTerm).map(_.asTerm)
-			.filter(_.isGetter).toList.map(_reflectField)
-		val (name, tipe, format) = _reflectTypeFormat(tip)
-		Swagger.JsonType(name, tipe, format, isArrayType, fields)
-	}
+  def reflect(tpe: Type): Swagger.JsonType = {
+    val isArrayType = isArrayType_?(tpe)
+    val tip = if (isArrayType) tpe.typeArgs.head else tpe
+    val fields = tip.decls.filter(_.isPublic)
+      .filter(_.isTerm).map(_.asTerm)
+      .filter(_.isGetter).toList.map(_reflectField)
+    val (name, tipe, format) = _reflectTypeFormat(tip)
+    Swagger.JsonType(name, tipe, format, isArrayType, fields)
+  }
 
 }

--- a/src/main/scala/xitrum/annotation/SwaggerReflection.scala
+++ b/src/main/scala/xitrum/annotation/SwaggerReflection.scala
@@ -1,0 +1,55 @@
+package xitrum.annotation
+
+import scala.reflect.runtime.universe._
+
+/**
+	* Utility functions to reflect scala case classes to structure that can be rendered to Swagger documentation
+	* User: smeagol74
+	* Date: 09.08.17
+	* Time: 0:02
+	*/
+object SwaggerReflection {
+
+	private val _arraySymbols = Set[Name](
+		symbolOf[Seq[_]].name,
+		symbolOf[Set[_]].name,
+		symbolOf[List[_]].name,
+		symbolOf[Array[_]].name
+	)
+
+	def isArrayType_?(tpe: Type): Boolean = _arraySymbols.contains(tpe.typeSymbol.name)
+
+
+	def _reflectField(fld: TermSymbol): Swagger.JsonField = {
+		val retType = fld.asMethod.returnType
+		val isRequired = retType.typeSymbol != symbolOf[Option[_]]
+		val tpe = if (isRequired) retType else retType.typeArgs.head
+		Swagger.JsonField(fld.name.toString, reflect(tpe), isRequired)
+	}
+
+	def _reflectTypeFormat(tpe: Type): (Option[String], String, String) = tpe.typeSymbol match {
+		case t if t == definitions.IntClass => (None, Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32)
+		case t if t == definitions.LongClass => (None, Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64)
+		case t if t == definitions.FloatClass => (None, Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float)
+		case t if t == definitions.DoubleClass => (None, Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double)
+		case t if t == definitions.StringClass => (None, Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none)
+		case t if t == definitions.BooleanClass => (None, Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none)
+		case t if t == symbolOf[java.util.Date] => (None, Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime)
+		case _ =>
+			var pack = tpe.typeSymbol.owner
+			while (!pack.isPackage)
+				pack = pack.owner
+			(Some(tpe.typeSymbol.fullName.toString.substring(pack.fullName.length + 1)), Swagger.JsonType.tpe.obj, Swagger.JsonType.fmt.none)
+	}
+
+	def reflect(tpe: Type): Swagger.JsonType = {
+		val isArrayType = isArrayType_?(tpe)
+		val tip = if (isArrayType) tpe.typeArgs.head else tpe
+		val fields = tip.decls.filter(_.isPublic)
+			.filter(_.isTerm).map(_.asTerm)
+			.filter(_.isGetter).toList.map(_reflectField)
+		val (name, tipe, format) = _reflectTypeFormat(tip)
+		Swagger.JsonType(name, tipe, format, isArrayType, fields)
+	}
+
+}

--- a/src/main/scala/xitrum/routing/ActionTreeBuilder.scala
+++ b/src/main/scala/xitrum/routing/ActionTreeBuilder.scala
@@ -87,7 +87,8 @@ private case class ActionTreeBuilder(xitrumVersion: String, parent2Children: Map
             }
           }
 
-          val universeAnnotations = runtimeMirror.classSymbol(klass).asClass.annotations
+          val universeClass = runtimeMirror.classSymbol(klass).asClass
+          val universeAnnotations = universeClass.annotations
           val thisAnnotationsOnly = ActionAnnotations.fromUniverse(universeAnnotations)
           val ret                 = thisAnnotationsOnly.inherit(parentAnnotations)
           cache(className)        = ret

--- a/src/main/scala/xitrum/routing/ActionTreeBuilder.scala
+++ b/src/main/scala/xitrum/routing/ActionTreeBuilder.scala
@@ -50,7 +50,6 @@ private case class ActionTreeBuilder(xitrumVersion: String, parent2Children: Map
    *
    * @param cl In development mode, we must use a new throwaway class loader,
    *        so that modified annotations (if any) can be recollected
-   *
    * @return Concrete (non-trait) action classes and their annotations
    */
   def getConcreteActionsAndAnnotations(cl: ClassLoader): Set[(Class[_ <: Action], ActionAnnotations)] = {
@@ -87,8 +86,7 @@ private case class ActionTreeBuilder(xitrumVersion: String, parent2Children: Map
             }
           }
 
-          val universeClass = runtimeMirror.classSymbol(klass).asClass
-          val universeAnnotations = universeClass.annotations
+          val universeAnnotations = runtimeMirror.classSymbol(klass).asClass.annotations
           val thisAnnotationsOnly = ActionAnnotations.fromUniverse(universeAnnotations)
           val ret                 = thisAnnotationsOnly.inherit(parentAnnotations)
           cache(className)        = ret
@@ -103,6 +101,7 @@ private case class ActionTreeBuilder(xitrumVersion: String, parent2Children: Map
 
   private def getConcreteActions: Set[Class[_ <: Action]] = {
     var concreteActions = Set.empty[Class[_ <: Action]]
+
     def traverseActionTree(className: String) {
       if (parent2Children.isDefinedAt(className)) {
         val children = parent2Children(className)

--- a/src/main/scala/xitrum/routing/RouteCollector.scala
+++ b/src/main/scala/xitrum/routing/RouteCollector.scala
@@ -4,6 +4,7 @@ import java.io.File
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.runtime.universe
 import scala.util.control.NonFatal
+import scala.tools.reflect.ToolBox
 
 import sclasner.{FileEntry, Scanner}
 
@@ -12,343 +13,272 @@ import xitrum.annotation._
 import xitrum.sockjs.SockJsPrefix
 
 case class DiscoveredAcc(
-  xitrumVersion:             String,
-  normalRoutes:              SerializableRouteCollection,
-  sockJsWithoutPrefixRoutes: SerializableRouteCollection,
-  sockJsMap:                 Map[String, SockJsClassAndOptions],
-  swaggerMap:                Map[Class[_ <: Action], Swagger]
-)
+	                        xitrumVersion: String,
+	                        normalRoutes: SerializableRouteCollection,
+	                        sockJsWithoutPrefixRoutes: SerializableRouteCollection,
+	                        sockJsMap: Map[String, SockJsClassAndOptions],
+	                        swaggerMap: Map[Class[_ <: Action], Swagger]
+                        )
 
 /** Scan all classes to collect routes from actions. */
 object RouteCollector {
-  import ActionAnnotations._
 
-  def deserializeCacheFileOrRecollect(cachedFile: File, cl: ClassLoader): DiscoveredAcc = {
-    var acc = DiscoveredAcc(
-      "<Invalid Xitrum version>",
-      new SerializableRouteCollection,
-      new SerializableRouteCollection,
-      Map.empty[String, SockJsClassAndOptions],
-      Map.empty[Class[_ <: Action], Swagger]
-    )
+	import ActionAnnotations._
 
-    // Only serialize/deserialize ActionTreeBuilder, which represents
-    // traits/classes extending Action, and their relationship. The relationship
-    // is for the (Swagger) annotation inheritance feature. The traits/classes
-    // are then loaded to get annotations.
-    val xitrumVersion     = xitrum.version.toString
-    val actionTreeBuilder = Scanner.foldLeft(cachedFile, ActionTreeBuilder(xitrumVersion), discovered(cl) _)
+	def deserializeCacheFileOrRecollect(cachedFile: File, cl: ClassLoader): DiscoveredAcc = {
+		var acc = DiscoveredAcc(
+			"<Invalid Xitrum version>",
+			new SerializableRouteCollection,
+			new SerializableRouteCollection,
+			Map.empty[String, SockJsClassAndOptions],
+			Map.empty[Class[_ <: Action], Swagger]
+		)
 
-    if (actionTreeBuilder.xitrumVersion != xitrumVersion) {
-      // The caller should see that the Xitrum version is invalid and act properly
-      acc
-    } else {
-      val ka = actionTreeBuilder.getConcreteActionsAndAnnotations(cl)
-      ka.foreach { case (klass, annotations) =>
-        acc = processAnnotations(acc, klass, annotations)
-      }
-      DiscoveredAcc(xitrumVersion, acc.normalRoutes, acc.sockJsWithoutPrefixRoutes, acc.sockJsMap, acc.swaggerMap)
-    }
-  }
+		// Only serialize/deserialize ActionTreeBuilder, which represents
+		// traits/classes extending Action, and their relationship. The relationship
+		// is for the (Swagger) annotation inheritance feature. The traits/classes
+		// are then loaded to get annotations.
+		val xitrumVersion = xitrum.version.toString
+		val actionTreeBuilder = Scanner.foldLeft(cachedFile, ActionTreeBuilder(xitrumVersion), discovered(cl) _)
 
-  //----------------------------------------------------------------------------
+		if (actionTreeBuilder.xitrumVersion != xitrumVersion) {
+			// The caller should see that the Xitrum version is invalid and act properly
+			acc
+		} else {
+			val ka = actionTreeBuilder.getConcreteActionsAndAnnotations(cl)
+			ka.foreach { case (klass, annotations) =>
+				acc = processAnnotations(acc, klass, annotations)
+			}
+			DiscoveredAcc(xitrumVersion, acc.normalRoutes, acc.sockJsWithoutPrefixRoutes, acc.sockJsMap, acc.swaggerMap)
+		}
+	}
 
-  private def discovered(cl: ClassLoader)(acc: ActionTreeBuilder, entry: FileEntry): ActionTreeBuilder = {
-    // At ActionTreeBuilder, we can't use ASM or Javassist to get annotations
-    // (because they don't understand Scala annotations), we have to actually
-    // classes anyway, here we guess class name from .class file name and
-    // load the class.
+	//----------------------------------------------------------------------------
 
-    if (!entry.relPath.endsWith(".class")) return acc
+	private def discovered(cl: ClassLoader)(acc: ActionTreeBuilder, entry: FileEntry): ActionTreeBuilder = {
+		// At ActionTreeBuilder, we can't use ASM or Javassist to get annotations
+		// (because they don't understand Scala annotations), we have to actually
+		// classes anyway, here we guess class name from .class file name and
+		// load the class.
 
-    // Optimize: Ignore standard Java, standard Scala, Netty classes etc.; these can be thousands
-    val relPath = if (File.separatorChar != '/') entry.relPath.replace(File.separatorChar, '/') else entry.relPath
-    if (IgnoredPackages.isIgnored(relPath)) return acc
+		if (!entry.relPath.endsWith(".class")) return acc
 
-    try {
-      val withoutExt      = relPath.substring(0, relPath.length - ".class".length)
-      val className       = withoutExt.replace('/', '.')
-      val klass           = cl.loadClass(className)
-      val superclass      = klass.getSuperclass.asInstanceOf[Class[_]]
-      val superclassNameo = if (superclass == null) None else Some(superclass.getName)
-      acc.addBranches(klass.getName, superclassNameo, klass.getInterfaces.map(_.getName))
-    } catch {
-      // Probably java.lang.NoClassDefFoundError: javax/servlet/http/HttpServlet
-      case _: java.lang.Error =>
-        acc
+		// Optimize: Ignore standard Java, standard Scala, Netty classes etc.; these can be thousands
+		val relPath = if (File.separatorChar != '/') entry.relPath.replace(File.separatorChar, '/') else entry.relPath
+		if (IgnoredPackages.isIgnored(relPath)) return acc
 
-      // Probably the .class file name -> class name guess was wrong
-      case NonFatal(_) =>
-        acc
-    }
-  }
+		try {
+			val withoutExt = relPath.substring(0, relPath.length - ".class".length)
+			val className = withoutExt.replace('/', '.')
+			val klass = cl.loadClass(className)
+			val superclass = klass.getSuperclass.asInstanceOf[Class[_]]
+			val superclassNameo = if (superclass == null) None else Some(superclass.getName)
+			acc.addBranches(klass.getName, superclassNameo, klass.getInterfaces.map(_.getName))
+		} catch {
+			// Probably java.lang.NoClassDefFoundError: javax/servlet/http/HttpServlet
+			case _: java.lang.Error =>
+				acc
 
-  private def processAnnotations(
-      acc:         DiscoveredAcc,
-      klass:       Class[_ <: Action],
-      annotations: ActionAnnotations
-  ): DiscoveredAcc = {
-    val className  = klass.getName
-    val fromSockJs = className.startsWith(classOf[SockJsPrefix].getPackage.getName)
-    val routes     = if (fromSockJs) acc.sockJsWithoutPrefixRoutes else acc.normalRoutes
+			// Probably the .class file name -> class name guess was wrong
+			case NonFatal(_) =>
+				acc
+		}
+	}
 
-    collectNormalRoutes(routes, className, annotations)
-    val newSockJsMap = collectSockJsMap(acc.sockJsMap, className, annotations)
-    collectErrorRoutes(routes, className, annotations)
+	private def processAnnotations(
+		                              acc: DiscoveredAcc,
+		                              klass: Class[_ <: Action],
+		                              annotations: ActionAnnotations
+	                              ): DiscoveredAcc = {
+		val className = klass.getName
+		val fromSockJs = className.startsWith(classOf[SockJsPrefix].getPackage.getName)
+		val routes = if (fromSockJs) acc.sockJsWithoutPrefixRoutes else acc.normalRoutes
 
-    val newSwaggerMap = collectSwagger(annotations) match {
-      case None          => acc.swaggerMap
-      case Some(swagger) => acc.swaggerMap + (klass -> swagger)
-    }
-    DiscoveredAcc(acc.xitrumVersion, acc.normalRoutes, acc.sockJsWithoutPrefixRoutes, newSockJsMap, newSwaggerMap)
-  }
+		collectNormalRoutes(routes, className, annotations)
+		val newSockJsMap = collectSockJsMap(acc.sockJsMap, className, annotations)
+		collectErrorRoutes(routes, className, annotations)
 
-  private def collectNormalRoutes(
-      routes:      SerializableRouteCollection,
-      className:   String,
-      annotations: ActionAnnotations
-  ) {
-    val routeOrder          = optRouteOrder(annotations.routeOrder)  // -1: first, 1: last, 0: other
-    val cacheSecs           = optCacheSecs(annotations.cache)        // < 0: cache action, > 0: cache page, 0: no cache
-    val method_pattern_coll = ArrayBuffer.empty[(String, String)]
+		val newSwaggerMap = collectSwagger(annotations) match {
+			case None => acc.swaggerMap
+			case Some(swagger) => acc.swaggerMap + (klass -> swagger)
+		}
+		DiscoveredAcc(acc.xitrumVersion, acc.normalRoutes, acc.sockJsWithoutPrefixRoutes, newSockJsMap, newSwaggerMap)
+	}
 
-    annotations.routes.foreach { a =>
-      listMethodAndPattern(a).foreach { m_p   => method_pattern_coll.append(m_p) }
-    }
+	private def collectNormalRoutes(
+		                               routes: SerializableRouteCollection,
+		                               className: String,
+		                               annotations: ActionAnnotations
+	                               ) {
+		val routeOrder = optRouteOrder(annotations.routeOrder) // -1: first, 1: last, 0: other
+		val cacheSecs = optCacheSecs(annotations.cache) // < 0: cache action, > 0: cache page, 0: no cache
+		val method_pattern_coll = ArrayBuffer.empty[(String, String)]
 
-    method_pattern_coll.foreach { case (method, pattern) =>
-      val compiledPattern   = RouteCompiler.compile(pattern)
-      val serializableRoute = new SerializableRoute(method, compiledPattern, className, cacheSecs)
-      val coll              = (routeOrder, method) match {
-        case (-1, "GET") => routes.firstGETs
-        case ( 1, "GET") => routes.lastGETs
-        case ( 0, "GET") => routes.otherGETs
+		annotations.routes.foreach { a =>
+			listMethodAndPattern(a).foreach { m_p => method_pattern_coll.append(m_p) }
+		}
 
-        case (-1, "POST") => routes.firstPOSTs
-        case ( 1, "POST") => routes.lastPOSTs
-        case ( 0, "POST") => routes.otherPOSTs
+		method_pattern_coll.foreach { case (method, pattern) =>
+			val compiledPattern = RouteCompiler.compile(pattern)
+			val serializableRoute = new SerializableRoute(method, compiledPattern, className, cacheSecs)
+			val coll = (routeOrder, method) match {
+				case (-1, "GET") => routes.firstGETs
+				case (1, "GET") => routes.lastGETs
+				case (0, "GET") => routes.otherGETs
 
-        case (-1, "PUT") => routes.firstPUTs
-        case ( 1, "PUT") => routes.lastPUTs
-        case ( 0, "PUT") => routes.otherPUTs
+				case (-1, "POST") => routes.firstPOSTs
+				case (1, "POST") => routes.lastPOSTs
+				case (0, "POST") => routes.otherPOSTs
 
-        case (-1, "PATCH") => routes.firstPATCHs
-        case ( 1, "PATCH") => routes.lastPATCHs
-        case ( 0, "PATCH") => routes.otherPATCHs
+				case (-1, "PUT") => routes.firstPUTs
+				case (1, "PUT") => routes.lastPUTs
+				case (0, "PUT") => routes.otherPUTs
 
-        case (-1, "DELETE") => routes.firstDELETEs
-        case ( 1, "DELETE") => routes.lastDELETEs
-        case ( 0, "DELETE") => routes.otherDELETEs
+				case (-1, "PATCH") => routes.firstPATCHs
+				case (1, "PATCH") => routes.lastPATCHs
+				case (0, "PATCH") => routes.otherPATCHs
 
-        case (-1, "WEBSOCKET") => routes.firstWEBSOCKETs
-        case ( 1, "WEBSOCKET") => routes.lastWEBSOCKETs
-        case ( 0, "WEBSOCKET") => routes.otherWEBSOCKETs
+				case (-1, "DELETE") => routes.firstDELETEs
+				case (1, "DELETE") => routes.lastDELETEs
+				case (0, "DELETE") => routes.otherDELETEs
 
-        case _ => throw new IllegalArgumentException
-      }
-      coll.append(serializableRoute)
-    }
-  }
+				case (-1, "WEBSOCKET") => routes.firstWEBSOCKETs
+				case (1, "WEBSOCKET") => routes.lastWEBSOCKETs
+				case (0, "WEBSOCKET") => routes.otherWEBSOCKETs
 
-  private def collectErrorRoutes(
-      routes:      SerializableRouteCollection,
-      className:   String,
-      annotations: ActionAnnotations)
-  {
-    annotations.error.foreach { a =>
-      val tpe       = a.tree.tpe
-      val tpeString = tpe.toString
-      if (tpeString == TYPE_OF_ERROR_404.toString) routes.error404 = Some(className)
-      if (tpeString == TYPE_OF_ERROR_500.toString) routes.error500 = Some(className)
-    }
-  }
+				case _ => throw new IllegalArgumentException
+			}
+			coll.append(serializableRoute)
+		}
+	}
 
-  private def collectSockJsMap(
-      sockJsMap:   Map[String, SockJsClassAndOptions],
-      className:   String,
-      annotations: ActionAnnotations
-  ): Map[String, SockJsClassAndOptions] =
-  {
-    var pathPrefix: String = null
-    annotations.routes.foreach { a =>
-      val tpe       = a.tree.tpe
-      val tpeString = tpe.toString
+	private def collectErrorRoutes(
+		                              routes: SerializableRouteCollection,
+		                              className: String,
+		                              annotations: ActionAnnotations) {
+		annotations.error.foreach { a =>
+			val tpe = a.tree.tpe
+			val tpeString = tpe.toString
+			if (tpeString == TYPE_OF_ERROR_404.toString) routes.error404 = Some(className)
+			if (tpeString == TYPE_OF_ERROR_500.toString) routes.error500 = Some(className)
+		}
+	}
 
-      if (tpeString == TYPE_OF_SOCKJS.toString)
-        pathPrefix = a.tree.children.tail.head.productElement(0).asInstanceOf[universe.Constant].value.toString
-    }
+	private def collectSockJsMap(
+		                            sockJsMap: Map[String, SockJsClassAndOptions],
+		                            className: String,
+		                            annotations: ActionAnnotations
+	                            ): Map[String, SockJsClassAndOptions] = {
+		var pathPrefix: String = null
+		annotations.routes.foreach { a =>
+			val tpe = a.tree.tpe
+			val tpeString = tpe.toString
 
-    if (pathPrefix == null) {
-      sockJsMap
-    } else {
-      val cl               = Thread.currentThread.getContextClassLoader
-      val sockJsActorClass = cl.loadClass(className).asInstanceOf[Class[SockJsAction]]
-      val noWebSocket      = annotations.sockJsNoWebSocket.isDefined
-      var cookieNeeded     = Config.xitrum.response.sockJsCookieNeeded
-      if (annotations.sockJsCookieNeeded  .isDefined) cookieNeeded = true
-      if (annotations.sockJsNoCookieNeeded.isDefined) cookieNeeded = false
-      sockJsMap + (pathPrefix -> new SockJsClassAndOptions(sockJsActorClass, !noWebSocket, cookieNeeded))
-    }
-  }
+			if (tpeString == TYPE_OF_SOCKJS.toString)
+				pathPrefix = a.tree.children.tail.head.productElement(0).asInstanceOf[universe.Constant].value.toString
+		}
 
-  //----------------------------------------------------------------------------
+		if (pathPrefix == null) {
+			sockJsMap
+		} else {
+			val cl = Thread.currentThread.getContextClassLoader
+			val sockJsActorClass = cl.loadClass(className).asInstanceOf[Class[SockJsAction]]
+			val noWebSocket = annotations.sockJsNoWebSocket.isDefined
+			var cookieNeeded = Config.xitrum.response.sockJsCookieNeeded
+			if (annotations.sockJsCookieNeeded.isDefined) cookieNeeded = true
+			if (annotations.sockJsNoCookieNeeded.isDefined) cookieNeeded = false
+			sockJsMap + (pathPrefix -> new SockJsClassAndOptions(sockJsActorClass, !noWebSocket, cookieNeeded))
+		}
+	}
 
-  /** -1: first, 1: last, 0: other */
-  private def optRouteOrder(annotationo: Option[universe.Annotation]): Int = {
-    annotationo match {
-      case None => 0
+	//----------------------------------------------------------------------------
 
-      case Some(annotation) =>
-        val tpe       = annotation.tree.tpe
-        val tpeString = tpe.toString
-        if (tpeString == TYPE_OF_FIRST.toString)
-          -1
-        else if (tpeString == TYPE_OF_LAST.toString)
-          1
-        else
-          0
-    }
-  }
+	/** -1: first, 1: last, 0: other */
+	private def optRouteOrder(annotationo: Option[universe.Annotation]): Int = {
+		annotationo match {
+			case None => 0
 
-  /** < 0: cache action, > 0: cache page, 0: no cache */
-  private def optCacheSecs(annotationo: Option[universe.Annotation]): Int = {
-    annotationo match {
-      case None => 0
+			case Some(annotation) =>
+				val tpe = annotation.tree.tpe
+				val tpeString = tpe.toString
+				if (tpeString == TYPE_OF_FIRST.toString)
+					-1
+				else if (tpeString == TYPE_OF_LAST.toString)
+					1
+				else
+					0
+		}
+	}
 
-      case Some(annotation) =>
-        val tpe       = annotation.tree.tpe
-        val tpeString = tpe.toString
+	/** < 0: cache action, > 0: cache page, 0: no cache */
+	private def optCacheSecs(annotationo: Option[universe.Annotation]): Int = {
+		annotationo match {
+			case None => 0
 
-        if (tpeString == TYPE_OF_CACHE_ACTION_DAY.toString)
-          -annotation.tree.children.tail.head.toString.toInt * 24 * 60 * 60
-        else if (tpeString == TYPE_OF_CACHE_ACTION_HOUR.toString)
-          -annotation.tree.children.tail.head.toString.toInt      * 60 * 60
-        else if (tpeString == TYPE_OF_CACHE_ACTION_MINUTE.toString)
-          -annotation.tree.children.tail.head.toString.toInt           * 60
-        else if (tpeString == TYPE_OF_CACHE_ACTION_SECOND.toString)
-          -annotation.tree.children.tail.head.toString.toInt
-        else if (tpeString == TYPE_OF_CACHE_PAGE_DAY.toString)
-          annotation.tree.children.tail.head.toString.toInt * 24 * 60 * 60
-        else if (tpeString == TYPE_OF_CACHE_PAGE_HOUR.toString)
-          annotation.tree.children.tail.head.toString.toInt      * 60 * 60
-        else if (tpeString == TYPE_OF_CACHE_PAGE_MINUTE.toString)
-          annotation.tree.children.tail.head.toString.toInt           * 60
-        else if (tpeString == TYPE_OF_CACHE_PAGE_SECOND.toString)
-          annotation.tree.children.tail.head.toString.toInt
-        else
-          0
-    }
-  }
+			case Some(annotation) =>
+				val tpe = annotation.tree.tpe
+				val tpeString = tpe.toString
 
-  /** @return Seq[(method, pattern)] */
-  private def listMethodAndPattern(annotation: universe.Annotation): Seq[(String, String)] = {
-    val tpe       = annotation.tree.tpe
-    val tpeString = tpe.toString
+				if (tpeString == TYPE_OF_CACHE_ACTION_DAY.toString)
+					-annotation.tree.children.tail.head.toString.toInt * 24 * 60 * 60
+				else if (tpeString == TYPE_OF_CACHE_ACTION_HOUR.toString)
+					-annotation.tree.children.tail.head.toString.toInt * 60 * 60
+				else if (tpeString == TYPE_OF_CACHE_ACTION_MINUTE.toString)
+					-annotation.tree.children.tail.head.toString.toInt * 60
+				else if (tpeString == TYPE_OF_CACHE_ACTION_SECOND.toString)
+					-annotation.tree.children.tail.head.toString.toInt
+				else if (tpeString == TYPE_OF_CACHE_PAGE_DAY.toString)
+					annotation.tree.children.tail.head.toString.toInt * 24 * 60 * 60
+				else if (tpeString == TYPE_OF_CACHE_PAGE_HOUR.toString)
+					annotation.tree.children.tail.head.toString.toInt * 60 * 60
+				else if (tpeString == TYPE_OF_CACHE_PAGE_MINUTE.toString)
+					annotation.tree.children.tail.head.toString.toInt * 60
+				else if (tpeString == TYPE_OF_CACHE_PAGE_SECOND.toString)
+					annotation.tree.children.tail.head.toString.toInt
+				else
+					0
+		}
+	}
 
-    if (tpeString == TYPE_OF_GET.toString)
-      getStrings(annotation).map(("GET", _))
-    else if (tpeString == TYPE_OF_POST.toString)
-      getStrings(annotation).map(("POST", _))
-    else if (tpeString == TYPE_OF_PUT.toString)
-      getStrings(annotation).map(("PUT", _))
-    else if (tpeString == TYPE_OF_PATCH.toString)
-      getStrings(annotation).map(("PATCH", _))
-    else if (tpeString == TYPE_OF_DELETE.toString)
-      getStrings(annotation).map(("DELETE", _))
-    else if (tpeString == TYPE_OF_WEBSOCKET.toString)
-      getStrings(annotation).map(("WEBSOCKET", _))
-    else
-      Seq.empty
-  }
+	/** @return Seq[(method, pattern)] */
+	private def listMethodAndPattern(annotation: universe.Annotation): Seq[(String, String)] = {
+		val tpe = annotation.tree.tpe
+		val tpeString = tpe.toString
 
-  private def getStrings(annotation: universe.Annotation): Seq[String] = {
-    annotation.tree.children.tail.map { tree => tree.productElement(0).asInstanceOf[universe.Constant].value.toString }
-  }
+		if (tpeString == TYPE_OF_GET.toString)
+			getStrings(annotation).map(("GET", _))
+		else if (tpeString == TYPE_OF_POST.toString)
+			getStrings(annotation).map(("POST", _))
+		else if (tpeString == TYPE_OF_PUT.toString)
+			getStrings(annotation).map(("PUT", _))
+		else if (tpeString == TYPE_OF_PATCH.toString)
+			getStrings(annotation).map(("PATCH", _))
+		else if (tpeString == TYPE_OF_DELETE.toString)
+			getStrings(annotation).map(("DELETE", _))
+		else if (tpeString == TYPE_OF_WEBSOCKET.toString)
+			getStrings(annotation).map(("WEBSOCKET", _))
+		else
+			Seq.empty
+	}
 
-  //----------------------------------------------------------------------------
+	private def getStrings(annotation: universe.Annotation): Seq[String] = {
+		annotation.tree.children.tail.map { tree => tree.productElement(0).asInstanceOf[universe.Constant].value.toString }
+	}
 
-  private def collectSwagger(annotations: ActionAnnotations): Option[Swagger] = {
-    val universeAnnotations = annotations.swaggers
-    if (universeAnnotations.isEmpty) {
-      None
-    } else {
-      var swaggerArgs = Seq.empty[SwaggerTypes.SwaggerArg]
-      universeAnnotations.foreach { annotation =>
-        annotation.tree.children.tail.foreach { scalaArg =>
-          // Ex:
-          // List(xitrum.annotation.Swagger.Response.apply, 200, "ID of the newly created article will be returned")
-          // List(xitrum.annotation.Swagger.StringForm.apply, "title", xitrum.annotation.Swagger.StringForm.apply$default$2)
-          // List(xitrum.annotation.Swagger.StringForm.apply, "title", "desc")
-          val children = scalaArg.children
+	//----------------------------------------------------------------------------
 
-          val child0 = children.head.toString
-          if (child0 == "xitrum.annotation.Swagger.Tags.apply") {
-            val tags = children.tail.map(_.productElement(0).asInstanceOf[universe.Constant].value.toString)
-            swaggerArgs = swaggerArgs :+ Swagger.Tags(tags: _*)
-          } else if (child0 == "xitrum.annotation.Swagger.Summary.apply") {
-            val summary = children(1).productElement(0).asInstanceOf[universe.Constant].value.toString
-            swaggerArgs = swaggerArgs :+ Swagger.Summary(summary)
-          } else if (child0 == "xitrum.annotation.Swagger.Description.apply") {
-            val description = children(1).productElement(0).asInstanceOf[universe.Constant].value.toString
-            swaggerArgs = swaggerArgs :+ Swagger.Description(description)
-          } else if (child0 == "xitrum.annotation.Swagger.ExternalDocs.apply") {
-            val url = children(1).productElement(0).asInstanceOf[universe.Constant].value.toString
-            val desc =
-              if (children(2).toString.startsWith("xitrum.annotation.Swagger"))
-                ""
-              else
-                children(2).productElement(0).asInstanceOf[universe.Constant].value.toString
-            swaggerArgs = swaggerArgs :+ Swagger.ExternalDocs(url, desc)
-          } else if (child0 == "xitrum.annotation.Swagger.OperationId.apply") {
-            val id = children(1).productElement(0).asInstanceOf[universe.Constant].value.toString
-            swaggerArgs = swaggerArgs :+ Swagger.OperationId(id)
-          } else if (child0 == "xitrum.annotation.Swagger.Consumes.apply") {
-            val contentTypes = children.tail.map(_.productElement(0).asInstanceOf[universe.Constant].value.toString)
-            swaggerArgs = swaggerArgs :+ Swagger.Consumes(contentTypes: _*)
-          } else if (child0 == "xitrum.annotation.Swagger.Produces.apply") {
-            val contentTypes = children.tail.map(_.productElement(0).asInstanceOf[universe.Constant].value.toString)
-            swaggerArgs = swaggerArgs :+ Swagger.Produces(contentTypes: _*)
-          } else if (child0 == "xitrum.annotation.Swagger.Response.apply") {
-            val code =
-              if (children(1).toString.startsWith("xitrum.annotation.Swagger"))
-                0
-              else
-                children(1).productElement(0).asInstanceOf[universe.Constant].value.toString.toInt
-            val desc = children(2).productElement(0).asInstanceOf[universe.Constant].value.toString
-            swaggerArgs = swaggerArgs :+ Swagger.Response(code, desc)
-          } else if (child0 == "xitrum.annotation.Swagger.Schemes.apply") {
-            val schemes = children.tail.map(_.productElement(0).asInstanceOf[universe.Constant].value.toString)
-            swaggerArgs = swaggerArgs :+ Swagger.Schemes(schemes: _*)
-          } else if (child0 == "xitrum.annotation.Swagger.Deprecated.apply") {
-            swaggerArgs = swaggerArgs :+ Swagger.Deprecated
-          } else {  // param or optional param
-            val name = children(1).productElement(0).asInstanceOf[universe.Constant].value.toString
+	private def collectSwagger(annotations: ActionAnnotations): Option[Swagger] = {
+		val universeAnnotations = annotations.swaggers
+		if (universeAnnotations.isEmpty) {
+			None
+		} else {
+			val cl = Thread.currentThread.getContextClassLoader
+			val rm = universe.runtimeMirror(cl)
+			val tb = rm.mkToolBox()
 
-            val desc =
-              if (children(2).toString.startsWith("xitrum.annotation.Swagger"))
-                ""
-              else
-                children(2).productElement(0).asInstanceOf[universe.Constant].value.toString
+			val swaggerArgs = universeAnnotations.map(annotation => tb.eval(tb.untypecheck(annotation.tree)).asInstanceOf[Swagger]).flatMap(_.swaggerArgs)
 
-            // Use reflection to create annotation
-
-            // Ex: xitrum.annotation.Swagger.StringForm.apply
-            val scalaClassName = child0.substring(0, child0.length - ".apply".length)
-
-            val builder = new StringBuilder(scalaClassName)
-            builder.setCharAt("xitrum.annotation.Swagger".length, '$')
-
-            // Ex: xitrum.annotation.Swagger$StringForm
-            val cl            = Thread.currentThread.getContextClassLoader
-            val javaClassName = builder.toString
-            val klass         = cl.loadClass(javaClassName)
-            val constructor   = klass.getConstructor(classOf[String], classOf[String])
-            swaggerArgs = swaggerArgs :+ constructor.newInstance(name, desc).asInstanceOf[SwaggerTypes.SwaggerArg]
-          }
-        }
-      }
-
-      Some(Swagger(swaggerArgs: _*))
-    }
-  }
+			Some(Swagger(swaggerArgs: _*))
+		}
+	}
 }

--- a/src/main/scala/xitrum/routing/RouteCollector.scala
+++ b/src/main/scala/xitrum/routing/RouteCollector.scala
@@ -316,7 +316,14 @@ object RouteCollector {
               else
                 children(1).productElement(0).asInstanceOf[universe.Constant].value.toString.toInt
             val desc = children(2).productElement(0).asInstanceOf[universe.Constant].value.toString
-            swaggerArgs = swaggerArgs :+ Swagger.Response(code, desc)
+
+            val cl = Thread.currentThread.getContextClassLoader
+            val rm = universe.runtimeMirror(cl)
+            val tb = rm.mkToolBox()
+
+            val tpeOpt = if (children.length > 3) tb.eval(tb.untypecheck(children(3))).asInstanceOf[Option[Swagger.JsonType]] else None
+
+            swaggerArgs = swaggerArgs :+ Swagger.Response(code, desc, tpeOpt)
           } else if (child0 == "xitrum.annotation.Swagger.Schemes.apply") {
             val schemes = children.tail.map(_.productElement(0).asInstanceOf[universe.Constant].value.toString)
             swaggerArgs = swaggerArgs :+ Swagger.Schemes(schemes: _*)

--- a/src/main/scala/xitrum/routing/RouteCollector.scala
+++ b/src/main/scala/xitrum/routing/RouteCollector.scala
@@ -13,272 +13,273 @@ import xitrum.annotation._
 import xitrum.sockjs.SockJsPrefix
 
 case class DiscoveredAcc(
-	                        xitrumVersion: String,
-	                        normalRoutes: SerializableRouteCollection,
-	                        sockJsWithoutPrefixRoutes: SerializableRouteCollection,
-	                        sockJsMap: Map[String, SockJsClassAndOptions],
-	                        swaggerMap: Map[Class[_ <: Action], Swagger]
-                        )
+  xitrumVersion:             String,
+  normalRoutes:              SerializableRouteCollection,
+  sockJsWithoutPrefixRoutes: SerializableRouteCollection,
+  sockJsMap:                 Map[String, SockJsClassAndOptions],
+  swaggerMap:                Map[Class[_ <: Action], Swagger]
+)
 
 /** Scan all classes to collect routes from actions. */
 object RouteCollector {
+  import ActionAnnotations._
 
-	import ActionAnnotations._
+  def deserializeCacheFileOrRecollect(cachedFile: File, cl: ClassLoader): DiscoveredAcc = {
+    var acc = DiscoveredAcc(
+      "<Invalid Xitrum version>",
+      new SerializableRouteCollection,
+      new SerializableRouteCollection,
+      Map.empty[String, SockJsClassAndOptions],
+      Map.empty[Class[_ <: Action], Swagger]
+    )
 
-	def deserializeCacheFileOrRecollect(cachedFile: File, cl: ClassLoader): DiscoveredAcc = {
-		var acc = DiscoveredAcc(
-			"<Invalid Xitrum version>",
-			new SerializableRouteCollection,
-			new SerializableRouteCollection,
-			Map.empty[String, SockJsClassAndOptions],
-			Map.empty[Class[_ <: Action], Swagger]
-		)
+    // Only serialize/deserialize ActionTreeBuilder, which represents
+    // traits/classes extending Action, and their relationship. The relationship
+    // is for the (Swagger) annotation inheritance feature. The traits/classes
+    // are then loaded to get annotations.
+    val xitrumVersion     = xitrum.version.toString
+    val actionTreeBuilder = Scanner.foldLeft(cachedFile, ActionTreeBuilder(xitrumVersion), discovered(cl) _)
 
-		// Only serialize/deserialize ActionTreeBuilder, which represents
-		// traits/classes extending Action, and their relationship. The relationship
-		// is for the (Swagger) annotation inheritance feature. The traits/classes
-		// are then loaded to get annotations.
-		val xitrumVersion = xitrum.version.toString
-		val actionTreeBuilder = Scanner.foldLeft(cachedFile, ActionTreeBuilder(xitrumVersion), discovered(cl) _)
+    if (actionTreeBuilder.xitrumVersion != xitrumVersion) {
+      // The caller should see that the Xitrum version is invalid and act properly
+      acc
+    } else {
+      val ka = actionTreeBuilder.getConcreteActionsAndAnnotations(cl)
+      ka.foreach { case (klass, annotations) =>
+        acc = processAnnotations(acc, klass, annotations)
+      }
+      DiscoveredAcc(xitrumVersion, acc.normalRoutes, acc.sockJsWithoutPrefixRoutes, acc.sockJsMap, acc.swaggerMap)
+    }
+  }
 
-		if (actionTreeBuilder.xitrumVersion != xitrumVersion) {
-			// The caller should see that the Xitrum version is invalid and act properly
-			acc
-		} else {
-			val ka = actionTreeBuilder.getConcreteActionsAndAnnotations(cl)
-			ka.foreach { case (klass, annotations) =>
-				acc = processAnnotations(acc, klass, annotations)
-			}
-			DiscoveredAcc(xitrumVersion, acc.normalRoutes, acc.sockJsWithoutPrefixRoutes, acc.sockJsMap, acc.swaggerMap)
-		}
-	}
+  //----------------------------------------------------------------------------
 
-	//----------------------------------------------------------------------------
+  private def discovered(cl: ClassLoader)(acc: ActionTreeBuilder, entry: FileEntry): ActionTreeBuilder = {
+    // At ActionTreeBuilder, we can't use ASM or Javassist to get annotations
+    // (because they don't understand Scala annotations), we have to actually
+    // classes anyway, here we guess class name from .class file name and
+    // load the class.
 
-	private def discovered(cl: ClassLoader)(acc: ActionTreeBuilder, entry: FileEntry): ActionTreeBuilder = {
-		// At ActionTreeBuilder, we can't use ASM or Javassist to get annotations
-		// (because they don't understand Scala annotations), we have to actually
-		// classes anyway, here we guess class name from .class file name and
-		// load the class.
+    if (!entry.relPath.endsWith(".class")) return acc
 
-		if (!entry.relPath.endsWith(".class")) return acc
+    // Optimize: Ignore standard Java, standard Scala, Netty classes etc.; these can be thousands
+    val relPath = if (File.separatorChar != '/') entry.relPath.replace(File.separatorChar, '/') else entry.relPath
+    if (IgnoredPackages.isIgnored(relPath)) return acc
 
-		// Optimize: Ignore standard Java, standard Scala, Netty classes etc.; these can be thousands
-		val relPath = if (File.separatorChar != '/') entry.relPath.replace(File.separatorChar, '/') else entry.relPath
-		if (IgnoredPackages.isIgnored(relPath)) return acc
+    try {
+      val withoutExt      = relPath.substring(0, relPath.length - ".class".length)
+      val className       = withoutExt.replace('/', '.')
+      val klass           = cl.loadClass(className)
+      val superclass      = klass.getSuperclass.asInstanceOf[Class[_]]
+      val superclassNameo = if (superclass == null) None else Some(superclass.getName)
+      acc.addBranches(klass.getName, superclassNameo, klass.getInterfaces.map(_.getName))
+    } catch {
+      // Probably java.lang.NoClassDefFoundError: javax/servlet/http/HttpServlet
+      case _: java.lang.Error =>
+        acc
 
-		try {
-			val withoutExt = relPath.substring(0, relPath.length - ".class".length)
-			val className = withoutExt.replace('/', '.')
-			val klass = cl.loadClass(className)
-			val superclass = klass.getSuperclass.asInstanceOf[Class[_]]
-			val superclassNameo = if (superclass == null) None else Some(superclass.getName)
-			acc.addBranches(klass.getName, superclassNameo, klass.getInterfaces.map(_.getName))
-		} catch {
-			// Probably java.lang.NoClassDefFoundError: javax/servlet/http/HttpServlet
-			case _: java.lang.Error =>
-				acc
+      // Probably the .class file name -> class name guess was wrong
+      case NonFatal(_) =>
+        acc
+    }
+  }
 
-			// Probably the .class file name -> class name guess was wrong
-			case NonFatal(_) =>
-				acc
-		}
-	}
+  private def processAnnotations(
+      acc:         DiscoveredAcc,
+      klass:       Class[_ <: Action],
+      annotations: ActionAnnotations
+  ): DiscoveredAcc = {
+    val className  = klass.getName
+    val fromSockJs = className.startsWith(classOf[SockJsPrefix].getPackage.getName)
+    val routes     = if (fromSockJs) acc.sockJsWithoutPrefixRoutes else acc.normalRoutes
 
-	private def processAnnotations(
-		                              acc: DiscoveredAcc,
-		                              klass: Class[_ <: Action],
-		                              annotations: ActionAnnotations
-	                              ): DiscoveredAcc = {
-		val className = klass.getName
-		val fromSockJs = className.startsWith(classOf[SockJsPrefix].getPackage.getName)
-		val routes = if (fromSockJs) acc.sockJsWithoutPrefixRoutes else acc.normalRoutes
+    collectNormalRoutes(routes, className, annotations)
+    val newSockJsMap = collectSockJsMap(acc.sockJsMap, className, annotations)
+    collectErrorRoutes(routes, className, annotations)
 
-		collectNormalRoutes(routes, className, annotations)
-		val newSockJsMap = collectSockJsMap(acc.sockJsMap, className, annotations)
-		collectErrorRoutes(routes, className, annotations)
+    val newSwaggerMap = collectSwagger(annotations) match {
+      case None          => acc.swaggerMap
+      case Some(swagger) => acc.swaggerMap + (klass -> swagger)
+    }
+    DiscoveredAcc(acc.xitrumVersion, acc.normalRoutes, acc.sockJsWithoutPrefixRoutes, newSockJsMap, newSwaggerMap)
+  }
 
-		val newSwaggerMap = collectSwagger(annotations) match {
-			case None => acc.swaggerMap
-			case Some(swagger) => acc.swaggerMap + (klass -> swagger)
-		}
-		DiscoveredAcc(acc.xitrumVersion, acc.normalRoutes, acc.sockJsWithoutPrefixRoutes, newSockJsMap, newSwaggerMap)
-	}
+  private def collectNormalRoutes(
+      routes:      SerializableRouteCollection,
+      className:   String,
+      annotations: ActionAnnotations
+  ) {
+    val routeOrder          = optRouteOrder(annotations.routeOrder)  // -1: first, 1: last, 0: other
+    val cacheSecs           = optCacheSecs(annotations.cache)        // < 0: cache action, > 0: cache page, 0: no cache
+    val method_pattern_coll = ArrayBuffer.empty[(String, String)]
 
-	private def collectNormalRoutes(
-		                               routes: SerializableRouteCollection,
-		                               className: String,
-		                               annotations: ActionAnnotations
-	                               ) {
-		val routeOrder = optRouteOrder(annotations.routeOrder) // -1: first, 1: last, 0: other
-		val cacheSecs = optCacheSecs(annotations.cache) // < 0: cache action, > 0: cache page, 0: no cache
-		val method_pattern_coll = ArrayBuffer.empty[(String, String)]
+    annotations.routes.foreach { a =>
+      listMethodAndPattern(a).foreach { m_p   => method_pattern_coll.append(m_p) }
+    }
 
-		annotations.routes.foreach { a =>
-			listMethodAndPattern(a).foreach { m_p => method_pattern_coll.append(m_p) }
-		}
+    method_pattern_coll.foreach { case (method, pattern) =>
+      val compiledPattern   = RouteCompiler.compile(pattern)
+      val serializableRoute = new SerializableRoute(method, compiledPattern, className, cacheSecs)
+      val coll              = (routeOrder, method) match {
+        case (-1, "GET") => routes.firstGETs
+        case ( 1, "GET") => routes.lastGETs
+        case ( 0, "GET") => routes.otherGETs
 
-		method_pattern_coll.foreach { case (method, pattern) =>
-			val compiledPattern = RouteCompiler.compile(pattern)
-			val serializableRoute = new SerializableRoute(method, compiledPattern, className, cacheSecs)
-			val coll = (routeOrder, method) match {
-				case (-1, "GET") => routes.firstGETs
-				case (1, "GET") => routes.lastGETs
-				case (0, "GET") => routes.otherGETs
+        case (-1, "POST") => routes.firstPOSTs
+        case ( 1, "POST") => routes.lastPOSTs
+        case ( 0, "POST") => routes.otherPOSTs
 
-				case (-1, "POST") => routes.firstPOSTs
-				case (1, "POST") => routes.lastPOSTs
-				case (0, "POST") => routes.otherPOSTs
+        case (-1, "PUT") => routes.firstPUTs
+        case ( 1, "PUT") => routes.lastPUTs
+        case ( 0, "PUT") => routes.otherPUTs
 
-				case (-1, "PUT") => routes.firstPUTs
-				case (1, "PUT") => routes.lastPUTs
-				case (0, "PUT") => routes.otherPUTs
+        case (-1, "PATCH") => routes.firstPATCHs
+        case ( 1, "PATCH") => routes.lastPATCHs
+        case ( 0, "PATCH") => routes.otherPATCHs
 
-				case (-1, "PATCH") => routes.firstPATCHs
-				case (1, "PATCH") => routes.lastPATCHs
-				case (0, "PATCH") => routes.otherPATCHs
+        case (-1, "DELETE") => routes.firstDELETEs
+        case ( 1, "DELETE") => routes.lastDELETEs
+        case ( 0, "DELETE") => routes.otherDELETEs
 
-				case (-1, "DELETE") => routes.firstDELETEs
-				case (1, "DELETE") => routes.lastDELETEs
-				case (0, "DELETE") => routes.otherDELETEs
+        case (-1, "WEBSOCKET") => routes.firstWEBSOCKETs
+        case ( 1, "WEBSOCKET") => routes.lastWEBSOCKETs
+        case ( 0, "WEBSOCKET") => routes.otherWEBSOCKETs
 
-				case (-1, "WEBSOCKET") => routes.firstWEBSOCKETs
-				case (1, "WEBSOCKET") => routes.lastWEBSOCKETs
-				case (0, "WEBSOCKET") => routes.otherWEBSOCKETs
+        case _ => throw new IllegalArgumentException
+      }
+      coll.append(serializableRoute)
+    }
+  }
 
-				case _ => throw new IllegalArgumentException
-			}
-			coll.append(serializableRoute)
-		}
-	}
+  private def collectErrorRoutes(
+      routes:      SerializableRouteCollection,
+      className:   String,
+      annotations: ActionAnnotations)
+  {
+    annotations.error.foreach { a =>
+      val tpe       = a.tree.tpe
+      val tpeString = tpe.toString
+      if (tpeString == TYPE_OF_ERROR_404.toString) routes.error404 = Some(className)
+      if (tpeString == TYPE_OF_ERROR_500.toString) routes.error500 = Some(className)
+    }
+  }
 
-	private def collectErrorRoutes(
-		                              routes: SerializableRouteCollection,
-		                              className: String,
-		                              annotations: ActionAnnotations) {
-		annotations.error.foreach { a =>
-			val tpe = a.tree.tpe
-			val tpeString = tpe.toString
-			if (tpeString == TYPE_OF_ERROR_404.toString) routes.error404 = Some(className)
-			if (tpeString == TYPE_OF_ERROR_500.toString) routes.error500 = Some(className)
-		}
-	}
+  private def collectSockJsMap(
+      sockJsMap:   Map[String, SockJsClassAndOptions],
+      className:   String,
+      annotations: ActionAnnotations
+  ): Map[String, SockJsClassAndOptions] =
+  {
+    var pathPrefix: String = null
+    annotations.routes.foreach { a =>
+      val tpe       = a.tree.tpe
+      val tpeString = tpe.toString
 
-	private def collectSockJsMap(
-		                            sockJsMap: Map[String, SockJsClassAndOptions],
-		                            className: String,
-		                            annotations: ActionAnnotations
-	                            ): Map[String, SockJsClassAndOptions] = {
-		var pathPrefix: String = null
-		annotations.routes.foreach { a =>
-			val tpe = a.tree.tpe
-			val tpeString = tpe.toString
+      if (tpeString == TYPE_OF_SOCKJS.toString)
+        pathPrefix = a.tree.children.tail.head.productElement(0).asInstanceOf[universe.Constant].value.toString
+    }
 
-			if (tpeString == TYPE_OF_SOCKJS.toString)
-				pathPrefix = a.tree.children.tail.head.productElement(0).asInstanceOf[universe.Constant].value.toString
-		}
+    if (pathPrefix == null) {
+      sockJsMap
+    } else {
+      val cl               = Thread.currentThread.getContextClassLoader
+      val sockJsActorClass = cl.loadClass(className).asInstanceOf[Class[SockJsAction]]
+      val noWebSocket      = annotations.sockJsNoWebSocket.isDefined
+      var cookieNeeded     = Config.xitrum.response.sockJsCookieNeeded
+      if (annotations.sockJsCookieNeeded  .isDefined) cookieNeeded = true
+      if (annotations.sockJsNoCookieNeeded.isDefined) cookieNeeded = false
+      sockJsMap + (pathPrefix -> new SockJsClassAndOptions(sockJsActorClass, !noWebSocket, cookieNeeded))
+    }
+  }
 
-		if (pathPrefix == null) {
-			sockJsMap
-		} else {
-			val cl = Thread.currentThread.getContextClassLoader
-			val sockJsActorClass = cl.loadClass(className).asInstanceOf[Class[SockJsAction]]
-			val noWebSocket = annotations.sockJsNoWebSocket.isDefined
-			var cookieNeeded = Config.xitrum.response.sockJsCookieNeeded
-			if (annotations.sockJsCookieNeeded.isDefined) cookieNeeded = true
-			if (annotations.sockJsNoCookieNeeded.isDefined) cookieNeeded = false
-			sockJsMap + (pathPrefix -> new SockJsClassAndOptions(sockJsActorClass, !noWebSocket, cookieNeeded))
-		}
-	}
+  //----------------------------------------------------------------------------
 
-	//----------------------------------------------------------------------------
+  /** -1: first, 1: last, 0: other */
+  private def optRouteOrder(annotationo: Option[universe.Annotation]): Int = {
+    annotationo match {
+      case None => 0
 
-	/** -1: first, 1: last, 0: other */
-	private def optRouteOrder(annotationo: Option[universe.Annotation]): Int = {
-		annotationo match {
-			case None => 0
+      case Some(annotation) =>
+        val tpe       = annotation.tree.tpe
+        val tpeString = tpe.toString
+        if (tpeString == TYPE_OF_FIRST.toString)
+          -1
+        else if (tpeString == TYPE_OF_LAST.toString)
+          1
+        else
+          0
+    }
+  }
 
-			case Some(annotation) =>
-				val tpe = annotation.tree.tpe
-				val tpeString = tpe.toString
-				if (tpeString == TYPE_OF_FIRST.toString)
-					-1
-				else if (tpeString == TYPE_OF_LAST.toString)
-					1
-				else
-					0
-		}
-	}
+  /** < 0: cache action, > 0: cache page, 0: no cache */
+  private def optCacheSecs(annotationo: Option[universe.Annotation]): Int = {
+    annotationo match {
+      case None => 0
 
-	/** < 0: cache action, > 0: cache page, 0: no cache */
-	private def optCacheSecs(annotationo: Option[universe.Annotation]): Int = {
-		annotationo match {
-			case None => 0
+      case Some(annotation) =>
+        val tpe       = annotation.tree.tpe
+        val tpeString = tpe.toString
 
-			case Some(annotation) =>
-				val tpe = annotation.tree.tpe
-				val tpeString = tpe.toString
+        if (tpeString == TYPE_OF_CACHE_ACTION_DAY.toString)
+          -annotation.tree.children.tail.head.toString.toInt * 24 * 60 * 60
+        else if (tpeString == TYPE_OF_CACHE_ACTION_HOUR.toString)
+          -annotation.tree.children.tail.head.toString.toInt      * 60 * 60
+        else if (tpeString == TYPE_OF_CACHE_ACTION_MINUTE.toString)
+          -annotation.tree.children.tail.head.toString.toInt           * 60
+        else if (tpeString == TYPE_OF_CACHE_ACTION_SECOND.toString)
+          -annotation.tree.children.tail.head.toString.toInt
+        else if (tpeString == TYPE_OF_CACHE_PAGE_DAY.toString)
+          annotation.tree.children.tail.head.toString.toInt * 24 * 60 * 60
+        else if (tpeString == TYPE_OF_CACHE_PAGE_HOUR.toString)
+          annotation.tree.children.tail.head.toString.toInt      * 60 * 60
+        else if (tpeString == TYPE_OF_CACHE_PAGE_MINUTE.toString)
+          annotation.tree.children.tail.head.toString.toInt           * 60
+        else if (tpeString == TYPE_OF_CACHE_PAGE_SECOND.toString)
+          annotation.tree.children.tail.head.toString.toInt
+        else
+          0
+    }
+  }
 
-				if (tpeString == TYPE_OF_CACHE_ACTION_DAY.toString)
-					-annotation.tree.children.tail.head.toString.toInt * 24 * 60 * 60
-				else if (tpeString == TYPE_OF_CACHE_ACTION_HOUR.toString)
-					-annotation.tree.children.tail.head.toString.toInt * 60 * 60
-				else if (tpeString == TYPE_OF_CACHE_ACTION_MINUTE.toString)
-					-annotation.tree.children.tail.head.toString.toInt * 60
-				else if (tpeString == TYPE_OF_CACHE_ACTION_SECOND.toString)
-					-annotation.tree.children.tail.head.toString.toInt
-				else if (tpeString == TYPE_OF_CACHE_PAGE_DAY.toString)
-					annotation.tree.children.tail.head.toString.toInt * 24 * 60 * 60
-				else if (tpeString == TYPE_OF_CACHE_PAGE_HOUR.toString)
-					annotation.tree.children.tail.head.toString.toInt * 60 * 60
-				else if (tpeString == TYPE_OF_CACHE_PAGE_MINUTE.toString)
-					annotation.tree.children.tail.head.toString.toInt * 60
-				else if (tpeString == TYPE_OF_CACHE_PAGE_SECOND.toString)
-					annotation.tree.children.tail.head.toString.toInt
-				else
-					0
-		}
-	}
+  /** @return Seq[(method, pattern)] */
+  private def listMethodAndPattern(annotation: universe.Annotation): Seq[(String, String)] = {
+    val tpe       = annotation.tree.tpe
+    val tpeString = tpe.toString
 
-	/** @return Seq[(method, pattern)] */
-	private def listMethodAndPattern(annotation: universe.Annotation): Seq[(String, String)] = {
-		val tpe = annotation.tree.tpe
-		val tpeString = tpe.toString
+    if (tpeString == TYPE_OF_GET.toString)
+      getStrings(annotation).map(("GET", _))
+    else if (tpeString == TYPE_OF_POST.toString)
+      getStrings(annotation).map(("POST", _))
+    else if (tpeString == TYPE_OF_PUT.toString)
+      getStrings(annotation).map(("PUT", _))
+    else if (tpeString == TYPE_OF_PATCH.toString)
+      getStrings(annotation).map(("PATCH", _))
+    else if (tpeString == TYPE_OF_DELETE.toString)
+      getStrings(annotation).map(("DELETE", _))
+    else if (tpeString == TYPE_OF_WEBSOCKET.toString)
+      getStrings(annotation).map(("WEBSOCKET", _))
+    else
+      Seq.empty
+  }
 
-		if (tpeString == TYPE_OF_GET.toString)
-			getStrings(annotation).map(("GET", _))
-		else if (tpeString == TYPE_OF_POST.toString)
-			getStrings(annotation).map(("POST", _))
-		else if (tpeString == TYPE_OF_PUT.toString)
-			getStrings(annotation).map(("PUT", _))
-		else if (tpeString == TYPE_OF_PATCH.toString)
-			getStrings(annotation).map(("PATCH", _))
-		else if (tpeString == TYPE_OF_DELETE.toString)
-			getStrings(annotation).map(("DELETE", _))
-		else if (tpeString == TYPE_OF_WEBSOCKET.toString)
-			getStrings(annotation).map(("WEBSOCKET", _))
-		else
-			Seq.empty
-	}
+  private def getStrings(annotation: universe.Annotation): Seq[String] = {
+    annotation.tree.children.tail.map { tree => tree.productElement(0).asInstanceOf[universe.Constant].value.toString }
+  }
 
-	private def getStrings(annotation: universe.Annotation): Seq[String] = {
-		annotation.tree.children.tail.map { tree => tree.productElement(0).asInstanceOf[universe.Constant].value.toString }
-	}
+  //----------------------------------------------------------------------------
 
-	//----------------------------------------------------------------------------
+  private def collectSwagger(annotations: ActionAnnotations): Option[Swagger] = {
+    val universeAnnotations = annotations.swaggers
+    if (universeAnnotations.isEmpty) {
+      None
+    } else {
+      val cl = Thread.currentThread.getContextClassLoader
+      val rm = universe.runtimeMirror(cl)
+      val tb = rm.mkToolBox()
 
-	private def collectSwagger(annotations: ActionAnnotations): Option[Swagger] = {
-		val universeAnnotations = annotations.swaggers
-		if (universeAnnotations.isEmpty) {
-			None
-		} else {
-			val cl = Thread.currentThread.getContextClassLoader
-			val rm = universe.runtimeMirror(cl)
-			val tb = rm.mkToolBox()
+      val swaggerArgs = universeAnnotations.map(annotation => tb.eval(tb.untypecheck(annotation.tree)).asInstanceOf[Swagger]).flatMap(_.swaggerArgs)
 
-			val swaggerArgs = universeAnnotations.map(annotation => tb.eval(tb.untypecheck(annotation.tree)).asInstanceOf[Swagger]).flatMap(_.swaggerArgs)
-
-			Some(Swagger(swaggerArgs: _*))
-		}
-	}
+      Some(Swagger(swaggerArgs: _*))
+    }
+  }
 }

--- a/src/main/scala/xitrum/routing/SwaggerActions.scala
+++ b/src/main/scala/xitrum/routing/SwaggerActions.scala
@@ -1,255 +1,350 @@
 package xitrum.routing
 
-import org.apache.commons.lang3.text.WordUtils
+import java.util.Date
 
-import org.json4s.JField
-import org.json4s.JsonAST.{JString, JArray, JValue, JObject}
+import org.apache.commons.lang3.text.WordUtils
+import org.json4s.{JField, JsonAST}
+import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods
-
-import xitrum.{FutureAction, Config}
+import xitrum.annotation.Swagger.JsonField
+import xitrum.{Config, FutureAction}
 import xitrum.annotation.{First, GET, Swagger, SwaggerTypes}
 
 import scala.collection.immutable.ListMap
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 @First
 @GET("xitrum/swagger.json")
 class SwaggerJson extends FutureAction {
-  def execute() {
-    respondJsonText(SwaggerJson.json)
-  }
+	def execute() {
+		respondJsonText(SwaggerJson.json)
+	}
 }
 
 /** Easy-to-remember path to Swagger UI: /xitrum/swagger */
 @First
 @GET("xitrum/swagger")
 class SwaggerUi extends FutureAction {
-  def execute() {
-    redirectTo(webJarsUrl("swagger-ui/3.0.10/dist/index.html?url=" + url[SwaggerJson]))
-  }
+	def execute() {
+		redirectTo(webJarsUrl("swagger-ui/3.0.10/dist/index.html?url=" + url[SwaggerJson]))
+	}
 }
 
 /** https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md */
 object SwaggerJson {
-  import SwaggerTypes._
 
-  private val SWAGGER_VERSION = "2.0"
+	import SwaggerTypes._
 
-  private val apiVersion = Config.xitrum.swaggerApiVersion.getOrElse("1.0")
+	private val SWAGGER_VERSION = "2.0"
 
-  /** Maybe set multiple times in development mode when reloading routes. */
-  private var prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
+	private val apiVersion = Config.xitrum.swaggerApiVersion.getOrElse("1.0")
 
-  //----------------------------------------------------------------------------
+	/** Maybe set multiple times in development mode when reloading routes. */
+	private var prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
 
-  def json: String = prettyJson
+	//----------------------------------------------------------------------------
 
-  /** Maybe called multiple times in development mode when reloading routes. */
-  def reloadFromRoutes() {
-    prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
-  }
+	def json: String = prettyJson
 
-  //----------------------------------------------------------------------------
+	private lazy val definitions = mutable.Map.empty[String, JValue]
 
-  private def getSwaggerObject: JValue = {
-    val info     = ("title" -> "APIs documented by Swagger") ~ ("version" -> apiVersion)
-    val basePath = if (Config.baseUrl.isEmpty) "/" else Config.baseUrl
-    ("swagger"  -> SWAGGER_VERSION) ~
-    ("info"     -> info) ~
-    ("basePath" -> basePath) ~
-    ("paths"    -> getPathsObject)
-  }
+	/** Maybe called multiple times in development mode when reloading routes. */
+	def reloadFromRoutes() {
+		prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
+	}
 
-  private def getPathsObject: JValue = {
-    // Shorter paths are often less complex than longer paths.
-    // We sort so that the API doc becomes easier to understand.
-    val sortedByPath = groupSwaggerRoutesByPath.toSeq.sortBy(_._1.length)
+	//----------------------------------------------------------------------------
 
-    val pathToPathItemObjects: Seq[(String, JValue)] =
-      sortedByPath.map { case (path, routes) =>
-        val pathItem = getPathItem(routes)
-        (path, pathItem)
-      }
-    JObject(pathToPathItemObjects: _*)
-  }
+	private def getSwaggerObject: JValue = {
+		val info = ("title" -> "APIs documented by Swagger") ~ ("version" -> apiVersion)
+		val basePath = if (Config.baseUrl.isEmpty) "/" else Config.baseUrl
+		("swagger" -> SWAGGER_VERSION) ~
+			("info" -> info) ~
+			("basePath" -> basePath) ~
+			("paths" -> getPathsObject) ~
+			("definitions" -> getDefinitionsObject)
+	}
 
-  private def groupSwaggerRoutesByPath: Map[String, Seq[Route]] = {
-    val swaggerMap = Config.routes.swaggerMap
+	private def getPathsObject: JValue = {
+		// Shorter paths are often less complex than longer paths.
+		// We sort so that the API doc becomes easier to understand.
+		val sortedByPath = groupSwaggerRoutesByPath.toSeq.sortBy(_._1.length)
 
-    // Use ListMap to preserve the order of routes
-    Config.routes.allFlatten().foldLeft(ListMap.empty[String, ArrayBuffer[Route]]) { (acc, route) =>
-      if (swaggerMap.contains(route.klass)) {
-        val path = RouteCompiler.decompile(route.compiledPattern, forSwagger = true)
-        acc.get(path) match {
-          case None =>
-            val routes = ArrayBuffer[Route](route)
-            acc.updated(path, routes)
+		val pathToPathItemObjects: Seq[(String, JValue)] =
+			sortedByPath.map { case (path, routes) =>
+				val pathItem = getPathItem(routes)
+				(path, pathItem)
+			}
+		JObject(pathToPathItemObjects: _*)
+	}
 
-          case Some(existingRoutes) =>
-            existingRoutes.append(route)
-            acc
-        }
-      } else {
-        acc
-      }
-    }
-  }
+	private def getDefinitionsObject: JValue = {
+		JObject(definitions.toList: _*)
+	}
 
-  private def getPathItem(routes: Seq[Route]): JValue = {
-    val methodToOperationObject: Seq[(String, JValue)] = routes.map { route =>
-      (route.httpMethod.name.toLowerCase, getOperation(route))
-    }
-    JObject(methodToOperationObject: _*)
-  }
+	private def groupSwaggerRoutesByPath: Map[String, Seq[Route]] = {
+		val swaggerMap = Config.routes.swaggerMap
 
-  private def getOperation(route: Route): JValue = {
-    val swagger = Config.routes.swaggerMap(route.klass)
-    val args    = swagger.swaggerArgs
+		// Use ListMap to preserve the order of routes
+		Config.routes.allFlatten().foldLeft(ListMap.empty[String, ArrayBuffer[Route]]) { (acc, route) =>
+			if (swaggerMap.contains(route.klass)) {
+				val path = RouteCompiler.decompile(route.compiledPattern, forSwagger = true)
+				acc.get(path) match {
+					case None =>
+						val routes = ArrayBuffer[Route](route)
+						acc.updated(path, routes)
 
-    val fields = Seq(
-      getTags(args),
-      getSummary(args, route),
-      getDescription(args),
-      getExternalDocs(args),
-      getOperationId(args, route),
-      getConsumes(args),
-      getProduces(args),
-      getParameters(args),
-      getResponses(args),
-      getSchemes(args),
-      getDeprecated(args)
-    ).flatten
-    JObject(fields: _*)
-  }
+					case Some(existingRoutes) =>
+						existingRoutes.append(route)
+						acc
+				}
+			} else {
+				acc
+			}
+		}
+	}
 
-  private def getTags(args: Seq[SwaggerArg]): Option[JField] = {
-    args.find(_.isInstanceOf[Swagger.Tags]).map { arg =>
-      "tags" -> arg.asInstanceOf[Swagger.Tags].tags
-    }
-  }
+	private def getPathItem(routes: Seq[Route]): JValue = {
+		val methodToOperationObject: Seq[(String, JValue)] = routes.map { route =>
+			(route.httpMethod.name.toLowerCase, getOperation(route))
+		}
+		JObject(methodToOperationObject: _*)
+	}
 
-  private def getSummary(args: Seq[SwaggerArg], route: Route): Option[JField] = {
-    val so = args.find(_.isInstanceOf[Swagger.Summary]).map { arg =>
-      arg.asInstanceOf[Swagger.Summary].summary
-    }
-    val co = getCacheInfo(route)
+	private def getOperation(route: Route): JValue = {
+		val swagger = Config.routes.swaggerMap(route.klass)
+		val args = swagger.swaggerArgs
 
-    (so, co) match {
-      case (None,    None)    => None
-      case (Some(s), Some(c)) => Some("summary" -> s"$s $c")
-      case _                  => Some("summary" -> so.orElse(co).get)
-    }
-  }
+		val fields = Seq(
+			getTags(args),
+			getSummary(args, route),
+			getDescription(args),
+			getExternalDocs(args),
+			getOperationId(args, route),
+			getConsumes(args),
+			getProduces(args),
+			getParameters(args),
+			getResponses(args),
+			getSchemes(args),
+			getDeprecated(args)
+		).flatten
+		JObject(fields: _*)
+	}
 
-  private def getCacheInfo(route: Route): Option[String] = {
-    val secs = route.cacheSecs
-    if (route.cacheSecs == 0)
-      None
-    else if (secs > 0)
-      Some(s"(Page cache: ${route.cacheSecs} [sec])")
-    else
-      Some(s"(Action cache: ${-route.cacheSecs} [sec])")
-  }
+	private def getTags(args: Seq[SwaggerArg]): Option[JField] = {
+		args.find(_.isInstanceOf[Swagger.Tags]).map { arg =>
+			"tags" -> arg.asInstanceOf[Swagger.Tags].tags
+		}
+	}
 
-  private def getDescription(args: Seq[SwaggerArg]): Option[JField] = {
-    args.find(_.isInstanceOf[Swagger.Description]).map { arg =>
-      "description" -> arg.asInstanceOf[Swagger.Description].desc
-    }
-  }
+	private def getSummary(args: Seq[SwaggerArg], route: Route): Option[JField] = {
+		val so = args.find(_.isInstanceOf[Swagger.Summary]).map { arg =>
+			arg.asInstanceOf[Swagger.Summary].summary
+		}
+		val co = getCacheInfo(route)
 
-  private def getExternalDocs(args: Seq[SwaggerArg]): Option[JField] = {
-    args.find(_.isInstanceOf[Swagger.ExternalDocs]).map { arg =>
-      val externalDocs = arg.asInstanceOf[Swagger.ExternalDocs]
-      "externalDocs" ->
-        ("description" -> externalDocs.desc) ~
-        ("url"         -> externalDocs.url)
-    }
-  }
+		(so, co) match {
+			case (None, None) => None
+			case (Some(s), Some(c)) => Some("summary" -> s"$s $c")
+			case _ => Some("summary" -> so.orElse(co).get)
+		}
+	}
 
-  private def getOperationId(args: Seq[SwaggerArg], route: Route): Option[JField] = {
-    val operationId = args.find(_.isInstanceOf[Swagger.OperationId]).map { arg =>
-      arg.asInstanceOf[Swagger.OperationId].id
-    }.getOrElse(
-      WordUtils.uncapitalize(route.klass.getSimpleName)
-    )
-    Some("operationId" -> operationId)
-  }
+	private def getCacheInfo(route: Route): Option[String] = {
+		val secs = route.cacheSecs
+		if (route.cacheSecs == 0)
+			None
+		else if (secs > 0)
+			Some(s"(Page cache: ${route.cacheSecs} [sec])")
+		else
+			Some(s"(Action cache: ${-route.cacheSecs} [sec])")
+	}
 
-  private def getConsumes(args: Seq[SwaggerArg]): Option[JField] = {
-    args.find(_.isInstanceOf[Swagger.Consumes]).map { arg =>
-      "consumes" -> arg.asInstanceOf[Swagger.Consumes].contentTypes
-    }
-  }
+	private def getDescription(args: Seq[SwaggerArg]): Option[JField] = {
+		args.find(_.isInstanceOf[Swagger.Description]).map { arg =>
+			"description" -> arg.asInstanceOf[Swagger.Description].desc
+		}
+	}
 
-  private def getProduces(args: Seq[SwaggerArg]): Option[JField] = {
-    args.find(_.isInstanceOf[Swagger.Produces]).map { arg =>
-      "produces" -> arg.asInstanceOf[Swagger.Produces].contentTypes
-    }
-  }
+	private def getExternalDocs(args: Seq[SwaggerArg]): Option[JField] = {
+		args.find(_.isInstanceOf[Swagger.ExternalDocs]).map { arg =>
+			val externalDocs = arg.asInstanceOf[Swagger.ExternalDocs]
+			"externalDocs" ->
+				("description" -> externalDocs.desc) ~
+					("url" -> externalDocs.url)
+		}
+	}
 
-  private def getParameters(args: Seq[SwaggerArg]): Option[JField] = {
-    val params = args.filter { arg =>
-      arg.isInstanceOf[SwaggerParamArg]
-    }.sortBy { arg =>  // Sort required params first, optional params later
-      if (arg.isInstanceOf[SwaggerOptParamArg]) 0 else -1
-    }.map { arg =>
-      getParameter(arg.asInstanceOf[SwaggerParamArg])
-    }
-    if (params.isEmpty) None else Some("parameters" -> JArray(params.toList))
-  }
+	private def _className(clazz: Class[_]): String = {
+		val pack = clazz.getPackage.getName
+		val name = clazz.getTypeName
+		name.substring(pack.length + 1)
+	}
 
-  private def getParameter(arg: SwaggerParamArg): JValue = {
-    val location = arg match {
-      case _: SwaggerPathParam   => "path"
-      case _: SwaggerQueryParam  => "query"
-      case _: SwaggerHeaderParam => "header"
-      case _: SwaggerBodyParam   => "body"
-      case _                     => "formData"
-    }
+	private def getOperationId(args: Seq[SwaggerArg], route: Route): Option[JField] = {
+		val operationId = args.find(_.isInstanceOf[Swagger.OperationId]).map { arg =>
+			arg.asInstanceOf[Swagger.OperationId].id
+		}.getOrElse(
+			WordUtils.uncapitalize(route.klass.getSimpleName)
+		)
+		Some("operationId" -> operationId)
+	}
 
-    val required = !arg.isInstanceOf[SwaggerOptParamArg]
+	private def getConsumes(args: Seq[SwaggerArg]): Option[JField] = {
+		args.find(_.isInstanceOf[Swagger.Consumes]).map { arg =>
+			"consumes" -> arg.asInstanceOf[Swagger.Consumes].contentTypes
+		}
+	}
 
-    val (tipe, format) = arg match {
-      case _: SwaggerIntParam      => ("integer",  "int32")
-      case _: SwaggerLongParam     => ("integer",  "int64")
-      case _: SwaggerFloatParam    => ("number",  "float")
-      case _: SwaggerDoubleParam   => ("number",  "double")
-      case _: SwaggerStringParam   => ("string",  "")
-      case _: SwaggerByteParam     => ("string",  "byte")
-      case _: SwaggerBinaryParam   => ("string",  "binary")
-      case _: SwaggerBooleanParam  => ("boolean", "")
-      case _: SwaggerDateParam     => ("string",  "date")
-      case _: SwaggerDateTimeParam => ("string",  "date-time")
-      case _: SwaggerPasswordParam => ("string",  "password")
-      case _: SwaggerFileParam     => ("file",    "")
-    }
+	private def getProduces(args: Seq[SwaggerArg]): Option[JField] = {
+		args.find(_.isInstanceOf[Swagger.Produces]).map { arg =>
+			"produces" -> arg.asInstanceOf[Swagger.Produces].contentTypes
+		}
+	}
 
-    ("name"        -> arg.name) ~
-    ("in"          -> location) ~
-    ("description" -> arg.desc) ~
-    ("required"    -> required) ~
-    ("type"        -> tipe) ~
-    ("format"      -> format)
-  }
+	private def getParameters(args: Seq[SwaggerArg]): Option[JField] = {
+		val params = args.filter { arg =>
+			arg.isInstanceOf[SwaggerParamArg]
+		}.sortBy { arg => // Sort required params first, optional params later
+			if (arg.isInstanceOf[SwaggerOptParamArg]) 0 else -1
+		}.map { arg =>
+			getParameter(arg.asInstanceOf[SwaggerParamArg])
+		}
+		if (params.isEmpty) None else Some("parameters" -> JArray(params.toList))
+	}
 
-  private def getResponses(args: Seq[SwaggerArg]): Option[JField] = {
-    val codeToDescs = args.filter(_.isInstanceOf[Swagger.Response]).map { arg =>
-      val response = arg.asInstanceOf[Swagger.Response]
-      val code = if (response.code <= 0) "default" else response.code.toString
-      val desc = response.desc
-      code -> JObject("description" -> JString(desc))
-    }
-    Some("responses" -> JObject(codeToDescs: _*))
-  }
+	private def _objectField(field: JsonField): (String, JObject) = {
+		field.name -> _autoJsonType(field.tpe, asField_? = true)
+	}
 
-  private def getSchemes(args: Seq[SwaggerArg]): Option[JField] = {
-    args.find(_.isInstanceOf[Swagger.Schemes]).map { arg =>
-      "schemes" -> arg.asInstanceOf[Swagger.Schemes].schemes
-    }
-  }
+	private def _addObjectDefinition(tpe: Swagger.JsonType): Unit = {
+		if (tpe.tpe == Swagger.JsonType.tpe.obj) {
+			val key = tpe.name.get
+			if (!definitions.contains(key)) {
+				var definition = ("type" -> "object") ~
+					("properties" -> JObject(tpe.fields.map(_objectField): _*))
+				val required = tpe.fields.filter(_.isRequired_?).map(_.name)
+				if (required.nonEmpty)
+					definition = definition ~
+						("required" -> required)
+				definitions.put(key, definition)
+			}
+		}
+	}
 
-  private def getDeprecated(args: Seq[SwaggerArg]): Option[JField] = {
-    if (args.contains(Swagger.Deprecated)) Some("deprecated" -> true) else None
-  }
+	private def _definitionPath(tpe: Swagger.JsonType): String = s"#/definitions/${tpe.name.get}"
+
+	private def _simpleType(tipe: String, format: String, withoutSchema_? : Boolean): JObject = {
+		val tpe = ("type" -> tipe) ~
+			("format" -> format)
+		if (withoutSchema_?)
+			tpe
+		else "schema" -> tpe
+	}
+
+	private def _simpleArrayType(tipe: String, format: String, withoutSchema_? : Boolean): JObject = {
+		val tpe = ("type" -> "array") ~
+			("items" -> _simpleType(tipe, format, withoutSchema_? = true))
+		if (withoutSchema_?)
+			tpe
+		else "schema" -> tpe
+	}
+
+	private def _objectArrayType(path: String, withoutSchema_? : Boolean): JObject = {
+		val tpe = ("type" -> "array") ~
+			("items" -> ("$ref" -> path))
+		if (withoutSchema_?)
+			tpe
+		else "schema" -> tpe
+	}
+
+
+	private def _objectType(path: String, withoutSchema_? : Boolean): JObject = {
+		val tpe = "$ref" -> path
+		if (withoutSchema_?)
+			tpe
+		else "schema" -> tpe
+	}
+
+	private def _autoJsonType(tpe: Swagger.JsonType, asField_? : Boolean = false): JObject = {
+		_addObjectDefinition(tpe)
+		tpe.tpe match {
+			case Swagger.JsonType.tpe.obj =>
+				if (tpe.isArray_?) {
+					_objectArrayType(_definitionPath(tpe), asField_?)
+				} else {
+					_objectType(_definitionPath(tpe), asField_?)
+				}
+			case _ =>
+				if (tpe.isArray_?) {
+					_simpleArrayType(tpe.tpe, tpe.format, asField_?)
+				} else {
+					_simpleType(tpe.tpe, tpe.format, asField_?)
+				}
+		}
+	}
+
+	private def getParameter(arg: SwaggerParamArg): JValue = {
+		val location = arg match {
+			case _: SwaggerPathParam => "path"
+			case _: SwaggerQueryParam => "query"
+			case _: SwaggerHeaderParam => "header"
+			case _: SwaggerBodyParam => "body"
+			case _ => "formData"
+		}
+
+		val required = !arg.isInstanceOf[SwaggerOptParamArg]
+
+		("name" -> arg.name) ~
+			("in" -> location) ~
+			("description" -> arg.desc) ~
+			("required" -> required) ~
+			(arg match {
+				case _: SwaggerIntParam => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32, withoutSchema_? = true)
+				case _: SwaggerLongParam => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64, withoutSchema_? = true)
+				case _: SwaggerFloatParam => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float, withoutSchema_? = true)
+				case _: SwaggerDoubleParam => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double, withoutSchema_? = true)
+				case _: SwaggerStringParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema_? = true)
+				case _: SwaggerByteParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.byte, withoutSchema_? = true)
+				case _: SwaggerBinaryParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.binary, withoutSchema_? = true)
+				case _: SwaggerBooleanParam => _simpleType(Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none, withoutSchema_? = true)
+				case _: SwaggerDateParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.date, withoutSchema_? = true)
+				case _: SwaggerDateTimeParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime, withoutSchema_? = true)
+				case _: SwaggerPasswordParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.password, withoutSchema_? = true)
+				case _: SwaggerFileParam => _simpleType(Swagger.JsonType.tpe.file, Swagger.JsonType.fmt.none, withoutSchema_? = true)
+				case _: SwaggerJsonParam => arg match {
+					case argJson: Swagger.JsonBody => _autoJsonType(argJson.tpe)
+					case _ => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema_? = true)
+				}
+			})
+	}
+
+
+	private def getResponses(args: Seq[SwaggerArg]): Option[JField] = {
+		val codeToDescs = args.filter(_.isInstanceOf[Swagger.Response]).map { arg =>
+			val response = arg.asInstanceOf[Swagger.Response]
+			val code = if (response.code <= 0) "default" else response.code.toString
+			val desc = response.desc
+			var details = JObject("description" -> JString(desc))
+			response.tpeOpt match {
+				case Some(tpe) =>
+					details = details ~ _autoJsonType(tpe)
+				case None =>
+			}
+			code -> details
+		}
+		Some("responses" -> JObject(codeToDescs: _*))
+	}
+
+	private def getSchemes(args: Seq[SwaggerArg]): Option[JField] = {
+		args.find(_.isInstanceOf[Swagger.Schemes]).map { arg =>
+			"schemes" -> arg.asInstanceOf[Swagger.Schemes].schemes
+		}
+	}
+
+	private def getDeprecated(args: Seq[SwaggerArg]): Option[JField] = {
+		if (args.contains(Swagger.Deprecated)) Some("deprecated" -> true) else None
+	}
 }

--- a/src/main/scala/xitrum/routing/SwaggerActions.scala
+++ b/src/main/scala/xitrum/routing/SwaggerActions.scala
@@ -1,15 +1,13 @@
 package xitrum.routing
 
-import java.util.Date
-
 import org.apache.commons.lang3.text.WordUtils
-import org.json4s.{JField, JsonAST}
-import org.json4s.JsonAST.{JArray, JObject, JString, JValue}
+import org.json4s.JField
+import org.json4s.JsonAST.{JString, JArray, JValue, JObject}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods
-import xitrum.annotation.Swagger.JsonField
-import xitrum.{Config, FutureAction}
+import xitrum.{FutureAction, Config}
 import xitrum.annotation.{First, GET, Swagger, SwaggerTypes}
+import xitrum.annotation.Swagger.JsonField
 
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
@@ -18,333 +16,327 @@ import scala.collection.mutable.ArrayBuffer
 @First
 @GET("xitrum/swagger.json")
 class SwaggerJson extends FutureAction {
-	def execute() {
-		respondJsonText(SwaggerJson.json)
-	}
+  def execute() {
+    respondJsonText(SwaggerJson.json)
+  }
 }
 
 /** Easy-to-remember path to Swagger UI: /xitrum/swagger */
 @First
 @GET("xitrum/swagger")
 class SwaggerUi extends FutureAction {
-	def execute() {
-		redirectTo(webJarsUrl("swagger-ui/3.0.10/dist/index.html?url=" + url[SwaggerJson]))
-	}
+  def execute() {
+    redirectTo(webJarsUrl("swagger-ui/3.0.10/dist/index.html?url=" + url[SwaggerJson]))
+  }
 }
 
 /** https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md */
 object SwaggerJson {
 
-	import SwaggerTypes._
+  import SwaggerTypes._
 
-	private val SWAGGER_VERSION = "2.0"
+  private val SWAGGER_VERSION = "2.0"
 
-	private val apiVersion = Config.xitrum.swaggerApiVersion.getOrElse("1.0")
+  private val apiVersion = Config.xitrum.swaggerApiVersion.getOrElse("1.0")
 
-	/** Maybe set multiple times in development mode when reloading routes. */
-	private var prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
+  /** Maybe set multiple times in development mode when reloading routes. */
+  private var prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
 
-	//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
-	def json: String = prettyJson
+  def json: String = prettyJson
 
-	private lazy val definitions = mutable.Map.empty[String, JValue]
+  private lazy val definitions = mutable.Map.empty[String, JValue]
 
-	/** Maybe called multiple times in development mode when reloading routes. */
-	def reloadFromRoutes() {
-		prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
-	}
+  /** Maybe called multiple times in development mode when reloading routes. */
+  def reloadFromRoutes() {
+    prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
+  }
 
-	//----------------------------------------------------------------------------
+  //----------------------------------------------------------------------------
 
-	private def getSwaggerObject: JValue = {
-		val info = ("title" -> "APIs documented by Swagger") ~ ("version" -> apiVersion)
-		val basePath = if (Config.baseUrl.isEmpty) "/" else Config.baseUrl
-		("swagger" -> SWAGGER_VERSION) ~
-			("info" -> info) ~
-			("basePath" -> basePath) ~
-			("paths" -> getPathsObject) ~
-			("definitions" -> getDefinitionsObject)
-	}
+  private def getSwaggerObject: JValue = {
+    val info     = ("title" -> "APIs documented by Swagger") ~ ("version" -> apiVersion)
+    val basePath = if (Config.baseUrl.isEmpty) "/" else Config.baseUrl
+    ("swagger"     -> SWAGGER_VERSION) ~
+    ("info"        -> info) ~
+    ("basePath"    -> basePath) ~
+    ("paths"       -> getPathsObject) ~
+    ("definitions" -> getDefinitionsObject)
+  }
 
-	private def getPathsObject: JValue = {
-		// Shorter paths are often less complex than longer paths.
-		// We sort so that the API doc becomes easier to understand.
-		val sortedByPath = groupSwaggerRoutesByPath.toSeq.sortBy(_._1.length)
+  private def getPathsObject: JValue = {
+    // Shorter paths are often less complex than longer paths.
+    // We sort so that the API doc becomes easier to understand.
+    val sortedByPath = groupSwaggerRoutesByPath.toSeq.sortBy(_._1.length)
 
-		val pathToPathItemObjects: Seq[(String, JValue)] =
-			sortedByPath.map { case (path, routes) =>
-				val pathItem = getPathItem(routes)
-				(path, pathItem)
-			}
-		JObject(pathToPathItemObjects: _*)
-	}
+    val pathToPathItemObjects: Seq[(String, JValue)] =
+      sortedByPath.map { case (path, routes) =>
+        val pathItem = getPathItem(routes)
+        (path, pathItem)
+      }
+    JObject(pathToPathItemObjects: _*)
+  }
 
-	private def getDefinitionsObject: JValue = {
-		JObject(definitions.toList: _*)
-	}
+  private def getDefinitionsObject: JValue = {
+    JObject(definitions.toList: _*)
+  }
 
-	private def groupSwaggerRoutesByPath: Map[String, Seq[Route]] = {
-		val swaggerMap = Config.routes.swaggerMap
+  private def groupSwaggerRoutesByPath: Map[String, Seq[Route]] = {
+    val swaggerMap = Config.routes.swaggerMap
 
-		// Use ListMap to preserve the order of routes
-		Config.routes.allFlatten().foldLeft(ListMap.empty[String, ArrayBuffer[Route]]) { (acc, route) =>
-			if (swaggerMap.contains(route.klass)) {
-				val path = RouteCompiler.decompile(route.compiledPattern, forSwagger = true)
-				acc.get(path) match {
-					case None =>
-						val routes = ArrayBuffer[Route](route)
-						acc.updated(path, routes)
+    // Use ListMap to preserve the order of routes
+    Config.routes.allFlatten().foldLeft(ListMap.empty[String, ArrayBuffer[Route]]) { (acc, route) =>
+      if (swaggerMap.contains(route.klass)) {
+        val path = RouteCompiler.decompile(route.compiledPattern, forSwagger = true)
+        acc.get(path) match {
+          case None =>
+            val routes = ArrayBuffer[Route](route)
+            acc.updated(path, routes)
 
-					case Some(existingRoutes) =>
-						existingRoutes.append(route)
-						acc
-				}
-			} else {
-				acc
-			}
-		}
-	}
+          case Some(existingRoutes) =>
+            existingRoutes.append(route)
+            acc
+        }
+      } else {
+        acc
+      }
+    }
+  }
 
-	private def getPathItem(routes: Seq[Route]): JValue = {
-		val methodToOperationObject: Seq[(String, JValue)] = routes.map { route =>
-			(route.httpMethod.name.toLowerCase, getOperation(route))
-		}
-		JObject(methodToOperationObject: _*)
-	}
+  private def getPathItem(routes: Seq[Route]): JValue = {
+    val methodToOperationObject: Seq[(String, JValue)] = routes.map { route =>
+      (route.httpMethod.name.toLowerCase, getOperation(route))
+    }
+    JObject(methodToOperationObject: _*)
+  }
 
-	private def getOperation(route: Route): JValue = {
-		val swagger = Config.routes.swaggerMap(route.klass)
-		val args = swagger.swaggerArgs
+  private def getOperation(route: Route): JValue = {
+    val swagger = Config.routes.swaggerMap(route.klass)
+    val args    = swagger.swaggerArgs
 
-		val fields = Seq(
-			getTags(args),
-			getSummary(args, route),
-			getDescription(args),
-			getExternalDocs(args),
-			getOperationId(args, route),
-			getConsumes(args),
-			getProduces(args),
-			getParameters(args),
-			getResponses(args),
-			getSchemes(args),
-			getDeprecated(args)
-		).flatten
-		JObject(fields: _*)
-	}
+    val fields = Seq(
+      getTags(args),
+      getSummary(args, route),
+      getDescription(args),
+      getExternalDocs(args),
+      getOperationId(args, route),
+      getConsumes(args),
+      getProduces(args),
+      getParameters(args),
+      getResponses(args),
+      getSchemes(args),
+      getDeprecated(args)
+    ).flatten
+    JObject(fields: _*)
+  }
 
-	private def getTags(args: Seq[SwaggerArg]): Option[JField] = {
-		args.find(_.isInstanceOf[Swagger.Tags]).map { arg =>
-			"tags" -> arg.asInstanceOf[Swagger.Tags].tags
-		}
-	}
+  private def getTags(args: Seq[SwaggerArg]): Option[JField] = {
+    args.find(_.isInstanceOf[Swagger.Tags]).map { arg =>
+      "tags" -> arg.asInstanceOf[Swagger.Tags].tags
+    }
+  }
 
-	private def getSummary(args: Seq[SwaggerArg], route: Route): Option[JField] = {
-		val so = args.find(_.isInstanceOf[Swagger.Summary]).map { arg =>
-			arg.asInstanceOf[Swagger.Summary].summary
-		}
-		val co = getCacheInfo(route)
+  private def getSummary(args: Seq[SwaggerArg], route: Route): Option[JField] = {
+    val so = args.find(_.isInstanceOf[Swagger.Summary]).map { arg =>
+      arg.asInstanceOf[Swagger.Summary].summary
+    }
+    val co = getCacheInfo(route)
 
-		(so, co) match {
-			case (None, None) => None
-			case (Some(s), Some(c)) => Some("summary" -> s"$s $c")
-			case _ => Some("summary" -> so.orElse(co).get)
-		}
-	}
+    (so, co) match {
+      case (None,    None)    => None
+      case (Some(s), Some(c)) => Some("summary" -> s"$s $c")
+      case _                  => Some("summary" -> so.orElse(co).get)
+    }
+  }
 
-	private def getCacheInfo(route: Route): Option[String] = {
-		val secs = route.cacheSecs
-		if (route.cacheSecs == 0)
-			None
-		else if (secs > 0)
-			Some(s"(Page cache: ${route.cacheSecs} [sec])")
-		else
-			Some(s"(Action cache: ${-route.cacheSecs} [sec])")
-	}
+  private def getCacheInfo(route: Route): Option[String] = {
+    val secs = route.cacheSecs
+    if (route.cacheSecs == 0)
+      None
+    else if (secs > 0)
+      Some(s"(Page cache: ${route.cacheSecs} [sec])")
+    else
+      Some(s"(Action cache: ${-route.cacheSecs} [sec])")
+  }
 
-	private def getDescription(args: Seq[SwaggerArg]): Option[JField] = {
-		args.find(_.isInstanceOf[Swagger.Description]).map { arg =>
-			"description" -> arg.asInstanceOf[Swagger.Description].desc
-		}
-	}
+  private def getDescription(args: Seq[SwaggerArg]): Option[JField] = {
+    args.find(_.isInstanceOf[Swagger.Description]).map { arg =>
+      "description" -> arg.asInstanceOf[Swagger.Description].desc
+    }
+  }
 
-	private def getExternalDocs(args: Seq[SwaggerArg]): Option[JField] = {
-		args.find(_.isInstanceOf[Swagger.ExternalDocs]).map { arg =>
-			val externalDocs = arg.asInstanceOf[Swagger.ExternalDocs]
-			"externalDocs" ->
-				("description" -> externalDocs.desc) ~
-					("url" -> externalDocs.url)
-		}
-	}
+  private def getExternalDocs(args: Seq[SwaggerArg]): Option[JField] = {
+    args.find(_.isInstanceOf[Swagger.ExternalDocs]).map { arg =>
+      val externalDocs = arg.asInstanceOf[Swagger.ExternalDocs]
+      "externalDocs" ->
+        ("description" -> externalDocs.desc) ~
+        ("url"         -> externalDocs.url)
+    }
+  }
 
-	private def _className(clazz: Class[_]): String = {
-		val pack = clazz.getPackage.getName
-		val name = clazz.getTypeName
-		name.substring(pack.length + 1)
-	}
+  private def getOperationId(args: Seq[SwaggerArg], route: Route): Option[JField] = {
+    val operationId = args.find(_.isInstanceOf[Swagger.OperationId]).map { arg =>
+      arg.asInstanceOf[Swagger.OperationId].id
+    }.getOrElse(
+      WordUtils.uncapitalize(route.klass.getSimpleName)
+    )
+    Some("operationId" -> operationId)
+  }
 
-	private def getOperationId(args: Seq[SwaggerArg], route: Route): Option[JField] = {
-		val operationId = args.find(_.isInstanceOf[Swagger.OperationId]).map { arg =>
-			arg.asInstanceOf[Swagger.OperationId].id
-		}.getOrElse(
-			WordUtils.uncapitalize(route.klass.getSimpleName)
-		)
-		Some("operationId" -> operationId)
-	}
+  private def getConsumes(args: Seq[SwaggerArg]): Option[JField] = {
+    args.find(_.isInstanceOf[Swagger.Consumes]).map { arg =>
+      "consumes" -> arg.asInstanceOf[Swagger.Consumes].contentTypes
+    }
+  }
 
-	private def getConsumes(args: Seq[SwaggerArg]): Option[JField] = {
-		args.find(_.isInstanceOf[Swagger.Consumes]).map { arg =>
-			"consumes" -> arg.asInstanceOf[Swagger.Consumes].contentTypes
-		}
-	}
+  private def getProduces(args: Seq[SwaggerArg]): Option[JField] = {
+    args.find(_.isInstanceOf[Swagger.Produces]).map { arg =>
+      "produces" -> arg.asInstanceOf[Swagger.Produces].contentTypes
+    }
+  }
 
-	private def getProduces(args: Seq[SwaggerArg]): Option[JField] = {
-		args.find(_.isInstanceOf[Swagger.Produces]).map { arg =>
-			"produces" -> arg.asInstanceOf[Swagger.Produces].contentTypes
-		}
-	}
+  private def getParameters(args: Seq[SwaggerArg]): Option[JField] = {
+    val params = args.filter { arg =>
+      arg.isInstanceOf[SwaggerParamArg]
+    }.sortBy { arg =>  // Sort required params first, optional params later
+      if (arg.isInstanceOf[SwaggerOptParamArg]) 0 else -1
+    }.map { arg =>
+      getParameter(arg.asInstanceOf[SwaggerParamArg])
+    }
+    if (params.isEmpty) None else Some("parameters" -> JArray(params.toList))
+  }
 
-	private def getParameters(args: Seq[SwaggerArg]): Option[JField] = {
-		val params = args.filter { arg =>
-			arg.isInstanceOf[SwaggerParamArg]
-		}.sortBy { arg => // Sort required params first, optional params later
-			if (arg.isInstanceOf[SwaggerOptParamArg]) 0 else -1
-		}.map { arg =>
-			getParameter(arg.asInstanceOf[SwaggerParamArg])
-		}
-		if (params.isEmpty) None else Some("parameters" -> JArray(params.toList))
-	}
+  private def _objectField(field: JsonField): (String, JObject) = {
+    field.name -> _autoJsonType(field.tpe, asField_? = true)
+  }
 
-	private def _objectField(field: JsonField): (String, JObject) = {
-		field.name -> _autoJsonType(field.tpe, asField_? = true)
-	}
+  private def _addObjectDefinition(tpe: Swagger.JsonType): Unit = {
+    if (tpe.tpe == Swagger.JsonType.tpe.obj) {
+      val key = tpe.name.get
+      if (!definitions.contains(key)) {
+        var definition = ("type" -> "object") ~
+          ("properties" -> JObject(tpe.fields.map(_objectField): _*))
+        val required = tpe.fields.filter(_.isRequired_?).map(_.name)
+        if (required.nonEmpty)
+          definition = definition ~
+            ("required" -> required)
+        definitions.put(key, definition)
+      }
+    }
+  }
 
-	private def _addObjectDefinition(tpe: Swagger.JsonType): Unit = {
-		if (tpe.tpe == Swagger.JsonType.tpe.obj) {
-			val key = tpe.name.get
-			if (!definitions.contains(key)) {
-				var definition = ("type" -> "object") ~
-					("properties" -> JObject(tpe.fields.map(_objectField): _*))
-				val required = tpe.fields.filter(_.isRequired_?).map(_.name)
-				if (required.nonEmpty)
-					definition = definition ~
-						("required" -> required)
-				definitions.put(key, definition)
-			}
-		}
-	}
+  private def _definitionPath(tpe: Swagger.JsonType): String = s"#/definitions/${tpe.name.get}"
 
-	private def _definitionPath(tpe: Swagger.JsonType): String = s"#/definitions/${tpe.name.get}"
+  private def _simpleType(tipe: String, format: String, withoutSchema_? : Boolean): JObject = {
+    val tpe = ("type" -> tipe) ~
+      ("format" -> format)
+    if (withoutSchema_?)
+      tpe
+    else "schema" -> tpe
+  }
 
-	private def _simpleType(tipe: String, format: String, withoutSchema_? : Boolean): JObject = {
-		val tpe = ("type" -> tipe) ~
-			("format" -> format)
-		if (withoutSchema_?)
-			tpe
-		else "schema" -> tpe
-	}
+  private def _simpleArrayType(tipe: String, format: String, withoutSchema_? : Boolean): JObject = {
+    val tpe = ("type" -> "array") ~
+      ("items" -> _simpleType(tipe, format, withoutSchema_? = true))
+    if (withoutSchema_?)
+      tpe
+    else "schema" -> tpe
+  }
 
-	private def _simpleArrayType(tipe: String, format: String, withoutSchema_? : Boolean): JObject = {
-		val tpe = ("type" -> "array") ~
-			("items" -> _simpleType(tipe, format, withoutSchema_? = true))
-		if (withoutSchema_?)
-			tpe
-		else "schema" -> tpe
-	}
-
-	private def _objectArrayType(path: String, withoutSchema_? : Boolean): JObject = {
-		val tpe = ("type" -> "array") ~
-			("items" -> ("$ref" -> path))
-		if (withoutSchema_?)
-			tpe
-		else "schema" -> tpe
-	}
+  private def _objectArrayType(path: String, withoutSchema_? : Boolean): JObject = {
+    val tpe = ("type" -> "array") ~
+      ("items" -> ("$ref" -> path))
+    if (withoutSchema_?)
+      tpe
+    else "schema" -> tpe
+  }
 
 
-	private def _objectType(path: String, withoutSchema_? : Boolean): JObject = {
-		val tpe = "$ref" -> path
-		if (withoutSchema_?)
-			tpe
-		else "schema" -> tpe
-	}
+  private def _objectType(path: String, withoutSchema_? : Boolean): JObject = {
+    val tpe = "$ref" -> path
+    if (withoutSchema_?)
+      tpe
+    else "schema" -> tpe
+  }
 
-	private def _autoJsonType(tpe: Swagger.JsonType, asField_? : Boolean = false): JObject = {
-		_addObjectDefinition(tpe)
-		tpe.tpe match {
-			case Swagger.JsonType.tpe.obj =>
-				if (tpe.isArray_?) {
-					_objectArrayType(_definitionPath(tpe), asField_?)
-				} else {
-					_objectType(_definitionPath(tpe), asField_?)
-				}
-			case _ =>
-				if (tpe.isArray_?) {
-					_simpleArrayType(tpe.tpe, tpe.format, asField_?)
-				} else {
-					_simpleType(tpe.tpe, tpe.format, asField_?)
-				}
-		}
-	}
+  private def _autoJsonType(tpe: Swagger.JsonType, asField_? : Boolean = false): JObject = {
+    _addObjectDefinition(tpe)
+    tpe.tpe match {
+      case Swagger.JsonType.tpe.obj =>
+        if (tpe.isArray_?) {
+          _objectArrayType(_definitionPath(tpe), asField_?)
+        } else {
+          _objectType(_definitionPath(tpe), asField_?)
+        }
+      case _ =>
+        if (tpe.isArray_?) {
+          _simpleArrayType(tpe.tpe, tpe.format, asField_?)
+        } else {
+          _simpleType(tpe.tpe, tpe.format, asField_?)
+        }
+    }
+  }
 
-	private def getParameter(arg: SwaggerParamArg): JValue = {
-		val location = arg match {
-			case _: SwaggerPathParam => "path"
-			case _: SwaggerQueryParam => "query"
-			case _: SwaggerHeaderParam => "header"
-			case _: SwaggerBodyParam => "body"
-			case _ => "formData"
-		}
+  private def getParameter(arg: SwaggerParamArg): JValue = {
+    val location = arg match {
+      case _: SwaggerPathParam   => "path"
+      case _: SwaggerQueryParam  => "query"
+      case _: SwaggerHeaderParam => "header"
+      case _: SwaggerBodyParam   => "body"
+      case _                     => "formData"
+    }
 
-		val required = !arg.isInstanceOf[SwaggerOptParamArg]
+    val required = !arg.isInstanceOf[SwaggerOptParamArg]
 
-		("name" -> arg.name) ~
-			("in" -> location) ~
-			("description" -> arg.desc) ~
-			("required" -> required) ~
-			(arg match {
-				case _: SwaggerIntParam => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32, withoutSchema_? = true)
-				case _: SwaggerLongParam => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64, withoutSchema_? = true)
-				case _: SwaggerFloatParam => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float, withoutSchema_? = true)
-				case _: SwaggerDoubleParam => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double, withoutSchema_? = true)
-				case _: SwaggerStringParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema_? = true)
-				case _: SwaggerByteParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.byte, withoutSchema_? = true)
-				case _: SwaggerBinaryParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.binary, withoutSchema_? = true)
-				case _: SwaggerBooleanParam => _simpleType(Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none, withoutSchema_? = true)
-				case _: SwaggerDateParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.date, withoutSchema_? = true)
-				case _: SwaggerDateTimeParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime, withoutSchema_? = true)
-				case _: SwaggerPasswordParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.password, withoutSchema_? = true)
-				case _: SwaggerFileParam => _simpleType(Swagger.JsonType.tpe.file, Swagger.JsonType.fmt.none, withoutSchema_? = true)
-				case _: SwaggerJsonParam => arg match {
-					case argJson: Swagger.JsonBody => _autoJsonType(argJson.tpe)
-					case _ => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema_? = true)
-				}
-			})
-	}
+    ("name"        -> arg.name) ~
+    ("in"          -> location) ~
+    ("description" -> arg.desc) ~
+    ("required"    -> required) ~
+    (arg match {
+      case _: SwaggerIntParam      => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32, withoutSchema_? = true)
+      case _: SwaggerLongParam     => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64, withoutSchema_? = true)
+      case _: SwaggerFloatParam    => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float, withoutSchema_? = true)
+      case _: SwaggerDoubleParam   => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double, withoutSchema_? = true)
+      case _: SwaggerStringParam   => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema_? = true)
+      case _: SwaggerByteParam     => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.byte, withoutSchema_? = true)
+      case _: SwaggerBinaryParam   => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.binary, withoutSchema_? = true)
+      case _: SwaggerBooleanParam  => _simpleType(Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none, withoutSchema_? = true)
+      case _: SwaggerDateParam     => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.date, withoutSchema_? = true)
+      case _: SwaggerDateTimeParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime, withoutSchema_? = true)
+      case _: SwaggerPasswordParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.password, withoutSchema_? = true)
+      case _: SwaggerFileParam     => _simpleType(Swagger.JsonType.tpe.file, Swagger.JsonType.fmt.none, withoutSchema_? = true)
+      case _: SwaggerJsonParam     => arg match {
+        case argJson: Swagger.JsonBody => _autoJsonType(argJson.tpe)
+        case _                         => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema_? = true)
+      }
+    })
+  }
 
 
-	private def getResponses(args: Seq[SwaggerArg]): Option[JField] = {
-		val codeToDescs = args.filter(_.isInstanceOf[Swagger.Response]).map { arg =>
-			val response = arg.asInstanceOf[Swagger.Response]
-			val code = if (response.code <= 0) "default" else response.code.toString
-			val desc = response.desc
-			var details = JObject("description" -> JString(desc))
-			response.tpeOpt match {
-				case Some(tpe) =>
-					details = details ~ _autoJsonType(tpe)
-				case None =>
-			}
-			code -> details
-		}
-		Some("responses" -> JObject(codeToDescs: _*))
-	}
+  private def getResponses(args: Seq[SwaggerArg]): Option[JField] = {
+    val codeToDescs = args.filter(_.isInstanceOf[Swagger.Response]).map { arg =>
+      val response = arg.asInstanceOf[Swagger.Response]
+      val code = if (response.code <= 0) "default" else response.code.toString
+      val desc = response.desc
+      var details = JObject("description" -> JString(desc))
+      response.tpeOpt match {
+        case Some(tpe) =>
+          details = details ~ _autoJsonType(tpe)
+        case None =>
+      }
+      code -> details
+    }
+    Some("responses" -> JObject(codeToDescs: _*))
+  }
 
-	private def getSchemes(args: Seq[SwaggerArg]): Option[JField] = {
-		args.find(_.isInstanceOf[Swagger.Schemes]).map { arg =>
-			"schemes" -> arg.asInstanceOf[Swagger.Schemes].schemes
-		}
-	}
+  private def getSchemes(args: Seq[SwaggerArg]): Option[JField] = {
+    args.find(_.isInstanceOf[Swagger.Schemes]).map { arg =>
+      "schemes" -> arg.asInstanceOf[Swagger.Schemes].schemes
+    }
+  }
 
-	private def getDeprecated(args: Seq[SwaggerArg]): Option[JField] = {
-		if (args.contains(Swagger.Deprecated)) Some("deprecated" -> true) else None
-	}
+  private def getDeprecated(args: Seq[SwaggerArg]): Option[JField] = {
+    if (args.contains(Swagger.Deprecated)) Some("deprecated" -> true) else None
+  }
 }

--- a/src/test/scala/xitrum/annotation/SwaggerReflectionSpec.scala
+++ b/src/test/scala/xitrum/annotation/SwaggerReflectionSpec.scala
@@ -1,0 +1,439 @@
+package xitrum.annotation
+
+import org.scalatest.FunSpec
+import scala.reflect.runtime.universe.{Type, typeOf}
+
+case class Sub1(name: String, value: Int)
+
+case class Sub2(key: String, value: Boolean)
+
+object Namespace {
+
+	case class Sub(name: String, value: Option[Int])
+
+}
+
+case class Test(
+	               int: Int,
+	               long: Long,
+	               float: Float,
+	               double: Double,
+	               string: String,
+	               boolean: Boolean,
+	               opInt: Option[Int],
+	               opLong: Option[Long],
+	               opFloat: Option[Float],
+	               opDouble: Option[Double],
+	               opString: Option[String],
+	               opBoolean: Option[Boolean],
+	               arrInt: Seq[Int],
+	               arrLong: List[Long],
+	               arrFloat: Array[Float],
+	               arrDouble: Set[Double],
+	               sub: Sub1,
+	               opSub: Option[Sub2],
+	               arrSub1: Seq[Sub1],
+	               arrSub2: Array[Sub2]
+               )
+
+/**
+	* User: smeagol
+	* Date: 09.08.17
+	* Time: 1:47
+	*/
+class SwaggerReflectionSpec extends FunSpec {
+
+	object jsonType {
+		def int(isArray_? : Boolean = false) = Swagger.JsonType(None, "integer", "int32", isArray_? = isArray_?)
+
+		def long(isArray_? : Boolean = false) = Swagger.JsonType(None, "integer", "int64", isArray_? = isArray_?)
+
+		def float(isArray_? : Boolean = false) = Swagger.JsonType(None, "number", "float", isArray_? = isArray_?)
+
+		def double(isArray_? : Boolean = false) = Swagger.JsonType(None, "number", "double", isArray_? = isArray_?)
+
+		def string(isArray_? : Boolean = false) = Swagger.JsonType(None, "string", isArray_? = isArray_?)
+
+		def boolean(isArray_? : Boolean = false) = Swagger.JsonType(None, "boolean", isArray_? = isArray_?)
+
+		def sub1(isArray_? : Boolean = false) = Swagger.JsonType(Some("Sub1"), "object", fields = Seq(
+			Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired_? = true),
+			Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"), isRequired_? = true)
+		), isArray_? = isArray_?)
+
+		def sub2(isArray_? : Boolean = false) = Swagger.JsonType(Some("Sub2"), "object", fields = Seq(
+			Swagger.JsonField("key", Swagger.JsonType(None, "string"), isRequired_? = true),
+			Swagger.JsonField("value", Swagger.JsonType(None, "boolean"), isRequired_? = true)
+		), isArray_? = isArray_?)
+
+		def sub(isArray_? : Boolean = false) = Swagger.JsonType(Some("Namespace.Sub"), "object", fields = Seq(
+			Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired_? = true),
+			Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"))
+		), isArray_? = isArray_?)
+
+	}
+
+	describe("SwaggerReflection") {
+
+		describe("_reflectField") {
+
+			val tpe = typeOf[Test]
+
+			def call(field: String): Swagger.JsonField = {
+				val fields = tpe.decls.filter(_.isPublic)
+					.filter(_.isTerm).map(_.asTerm)
+					.filter(_.isGetter)
+				val fld = fields.filter(_.name.toString == field).head
+				SwaggerReflection._reflectField(fld)
+			}
+
+			describe("Simple types") {
+				it("Int") {
+					assertResult(Swagger.JsonField("int", jsonType.int(), isRequired_? = true)) {
+						call("int")
+					}
+				}
+
+				it("Long") {
+					assertResult(Swagger.JsonField("long", jsonType.long(), isRequired_? = true)) {
+						call("long")
+					}
+				}
+
+				it("Float") {
+					assertResult(Swagger.JsonField("float", jsonType.float(), isRequired_? = true)) {
+						call("float")
+					}
+				}
+
+				it("Double") {
+					assertResult(Swagger.JsonField("double", jsonType.double(), isRequired_? = true)) {
+						call("double")
+					}
+				}
+
+				it("String") {
+					assertResult(Swagger.JsonField("string", jsonType.string(), isRequired_? = true)) {
+						call("string")
+					}
+				}
+
+				it("Boolean") {
+					assertResult(Swagger.JsonField("boolean", jsonType.boolean(), isRequired_? = true)) {
+						call("boolean")
+					}
+				}
+
+			}
+
+			describe("Optional simple types") {
+				it("Int") {
+					assertResult(Swagger.JsonField("opInt", jsonType.int())) {
+						call("opInt")
+					}
+				}
+
+				it("Long") {
+					assertResult(Swagger.JsonField("opLong", jsonType.long())) {
+						call("opLong")
+					}
+				}
+
+				it("Float") {
+					assertResult(Swagger.JsonField("opFloat", jsonType.float())) {
+						call("opFloat")
+					}
+				}
+
+				it("Double") {
+					assertResult(Swagger.JsonField("opDouble", jsonType.double())) {
+						call("opDouble")
+					}
+				}
+
+				it("String") {
+					assertResult(Swagger.JsonField("opString", jsonType.string())) {
+						call("opString")
+					}
+				}
+
+				it("Boolean") {
+					assertResult(Swagger.JsonField("opBoolean", jsonType.boolean())) {
+						call("opBoolean")
+					}
+				}
+
+			}
+
+			describe("Simple arrays") {
+				it("Seq") {
+					assertResult(Swagger.JsonField("arrInt", jsonType.int(true), isRequired_? = true)) {
+						call("arrInt")
+					}
+				}
+
+				it("List") {
+					assertResult(Swagger.JsonField("arrLong", jsonType.long(true), isRequired_? = true)) {
+						call("arrLong")
+					}
+				}
+
+				it("Array") {
+					assertResult(Swagger.JsonField("arrFloat", jsonType.float(true), isRequired_? = true)) {
+						call("arrFloat")
+					}
+				}
+
+				it("Set") {
+					assertResult(Swagger.JsonField("arrDouble", jsonType.double(true), isRequired_? = true)) {
+						call("arrDouble")
+					}
+				}
+
+			}
+
+			describe("Case classes") {
+				it("Sub1") {
+					assertResult(Swagger.JsonField("sub", jsonType.sub1(), isRequired_? = true)) {
+						call("sub")
+					}
+				}
+			}
+
+			describe("Optional case classes") {
+				it("Sub2") {
+					assertResult(Swagger.JsonField("opSub", jsonType.sub2())) {
+						call("opSub")
+					}
+				}
+
+			}
+
+			describe("Case classes arrays") {
+				it("Seq") {
+					assertResult(Swagger.JsonField("arrSub1", jsonType.sub1(true), isRequired_? = true)) {
+						call("arrSub1")
+					}
+				}
+
+				it("List") {
+					assertResult(Swagger.JsonField("arrSub2", jsonType.sub2(true), isRequired_? = true)) {
+						call("arrSub2")
+					}
+				}
+
+			}
+		}
+
+		describe("_reflectTypeFormat") {
+
+			def call(tpe: Type) = SwaggerReflection._reflectTypeFormat(tpe)
+
+			describe("Simple types") {
+				it("Int") {
+					assertResult((None, "integer", "int32")) {
+						call(typeOf[Int])
+					}
+				}
+
+				it("Long") {
+					assertResult((None, "integer", "int64")) {
+						call(typeOf[Long])
+					}
+				}
+
+				it("Float") {
+					assertResult((None, "number", "float")) {
+						call(typeOf[Float])
+					}
+				}
+
+				it("Double") {
+					assertResult((None, "number", "double")) {
+						call(typeOf[Double])
+					}
+				}
+
+				it("String") {
+					assertResult((None, "string", "")) {
+						call(typeOf[String])
+					}
+				}
+
+				it("Boolean") {
+					assertResult((None, "boolean", "")) {
+						call(typeOf[Boolean])
+					}
+				}
+
+			}
+
+			describe("Case classes") {
+				it("Sub1") {
+					assertResult((Some("Sub1"), "object", "")) {
+						call(typeOf[Sub1])
+					}
+				}
+
+				it("Sub2") {
+					assertResult((Some("Sub2"), "object", "")) {
+						call(typeOf[Sub2])
+					}
+				}
+
+				it("Namespace.Sub") {
+					assertResult((Some("Namespace.Sub"), "object", "")) {
+						call(typeOf[Namespace.Sub])
+					}
+				}
+			}
+
+		}
+
+		describe("isArrayType_?") {
+			def call(tpe: Type) = SwaggerReflection.isArrayType_?(tpe)
+
+			it("Seq") {
+				assert(call(typeOf[Seq[String]]))
+				assert(call(typeOf[Seq[Int]]))
+				assert(call(typeOf[Seq[(Int, Boolean)]]))
+			}
+
+			it("List") {
+				assert(call(typeOf[List[Float]]))
+				assert(call(typeOf[List[Boolean]]))
+				assert(call(typeOf[List[Sub1]]))
+			}
+
+			it("Array") {
+				assert(call(typeOf[Array[Long]]))
+				assert(call(typeOf[Array[String]]))
+				assert(call(typeOf[Array[Sub2]]))
+			}
+
+			it("Set") {
+				assert(call(typeOf[Set[Long]]))
+				assert(call(typeOf[Set[String]]))
+				assert(call(typeOf[Set[Namespace.Sub]]))
+			}
+		}
+
+		describe("reflect") {
+			def call(tpe: Type) = SwaggerReflection.reflect(tpe)
+
+			describe("Simple Types") {
+				it("Int") {
+					assertResult(jsonType.int()) {
+						call(typeOf[Int])
+					}
+				}
+
+				it("Long") {
+					assertResult(jsonType.long()) {
+						call(typeOf[Long])
+					}
+				}
+
+				it("Float") {
+					assertResult(jsonType.float()) {
+						call(typeOf[Float])
+					}
+				}
+
+				it("Double") {
+					assertResult(jsonType.double()) {
+						call(typeOf[Double])
+					}
+				}
+
+				it("String") {
+					assertResult(jsonType.string()) {
+						call(typeOf[String])
+					}
+				}
+
+				it("Boolean") {
+					assertResult(jsonType.boolean()) {
+						call(typeOf[Boolean])
+					}
+				}
+
+			}
+
+			describe("Simple Arrays") {
+				it("Seq") {
+					assertResult(jsonType.int(true)) {
+						call(typeOf[Seq[Int]])
+					}
+				}
+
+				it("List") {
+					assertResult(jsonType.long(true)) {
+						call(typeOf[List[Long]])
+					}
+				}
+
+				it("Array") {
+					assertResult(jsonType.float(true)) {
+						call(typeOf[Array[Float]])
+					}
+				}
+
+				it("Set") {
+					assertResult(jsonType.double(true)) {
+						call(typeOf[Set[Double]])
+					}
+				}
+
+			}
+
+			describe("Case Classes") {
+				it("Sub1") {
+					assertResult(jsonType.sub1()) {
+						call(typeOf[Sub1])
+					}
+				}
+				it("Sub2") {
+					assertResult(jsonType.sub2()) {
+						call(typeOf[Sub2])
+					}
+				}
+				it("Namespace.Sub") {
+					assertResult(jsonType.sub()) {
+						call(typeOf[Namespace.Sub])
+					}
+				}
+			}
+
+			describe("Case Classes Arrays") {
+				it("Seq") {
+					assertResult(jsonType.sub1(true)) {
+						call(typeOf[Seq[Sub1]])
+					}
+				}
+
+				it("List") {
+					assertResult(jsonType.sub2(true)) {
+						call(typeOf[List[Sub2]])
+					}
+				}
+
+				it("Array") {
+					assertResult(jsonType.sub(true)) {
+						call(typeOf[Array[Namespace.Sub]])
+					}
+				}
+
+				it("Set") {
+					assertResult(jsonType.sub(true)) {
+						call(typeOf[Set[Namespace.Sub]])
+					}
+				}
+
+			}
+		}
+
+	}
+
+}
+

--- a/src/test/scala/xitrum/annotation/SwaggerReflectionSpec.scala
+++ b/src/test/scala/xitrum/annotation/SwaggerReflectionSpec.scala
@@ -9,431 +9,431 @@ case class Sub2(key: String, value: Boolean)
 
 object Namespace {
 
-	case class Sub(name: String, value: Option[Int])
+  case class Sub(name: String, value: Option[Int])
 
 }
 
 case class Test(
-	               int: Int,
-	               long: Long,
-	               float: Float,
-	               double: Double,
-	               string: String,
-	               boolean: Boolean,
-	               opInt: Option[Int],
-	               opLong: Option[Long],
-	               opFloat: Option[Float],
-	               opDouble: Option[Double],
-	               opString: Option[String],
-	               opBoolean: Option[Boolean],
-	               arrInt: Seq[Int],
-	               arrLong: List[Long],
-	               arrFloat: Array[Float],
-	               arrDouble: Set[Double],
-	               sub: Sub1,
-	               opSub: Option[Sub2],
-	               arrSub1: Seq[Sub1],
-	               arrSub2: Array[Sub2]
+                 int: Int,
+                 long: Long,
+                 float: Float,
+                 double: Double,
+                 string: String,
+                 boolean: Boolean,
+                 opInt: Option[Int],
+                 opLong: Option[Long],
+                 opFloat: Option[Float],
+                 opDouble: Option[Double],
+                 opString: Option[String],
+                 opBoolean: Option[Boolean],
+                 arrInt: Seq[Int],
+                 arrLong: List[Long],
+                 arrFloat: Array[Float],
+                 arrDouble: Set[Double],
+                 sub: Sub1,
+                 opSub: Option[Sub2],
+                 arrSub1: Seq[Sub1],
+                 arrSub2: Array[Sub2]
                )
 
 /**
-	* User: smeagol
-	* Date: 09.08.17
-	* Time: 1:47
-	*/
+  * User: smeagol
+  * Date: 09.08.17
+  * Time: 1:47
+  */
 class SwaggerReflectionSpec extends FunSpec {
 
-	object jsonType {
-		def int(isArray_? : Boolean = false) = Swagger.JsonType(None, "integer", "int32", isArray_? = isArray_?)
-
-		def long(isArray_? : Boolean = false) = Swagger.JsonType(None, "integer", "int64", isArray_? = isArray_?)
-
-		def float(isArray_? : Boolean = false) = Swagger.JsonType(None, "number", "float", isArray_? = isArray_?)
-
-		def double(isArray_? : Boolean = false) = Swagger.JsonType(None, "number", "double", isArray_? = isArray_?)
-
-		def string(isArray_? : Boolean = false) = Swagger.JsonType(None, "string", isArray_? = isArray_?)
-
-		def boolean(isArray_? : Boolean = false) = Swagger.JsonType(None, "boolean", isArray_? = isArray_?)
-
-		def sub1(isArray_? : Boolean = false) = Swagger.JsonType(Some("Sub1"), "object", fields = Seq(
-			Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired_? = true),
-			Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"), isRequired_? = true)
-		), isArray_? = isArray_?)
-
-		def sub2(isArray_? : Boolean = false) = Swagger.JsonType(Some("Sub2"), "object", fields = Seq(
-			Swagger.JsonField("key", Swagger.JsonType(None, "string"), isRequired_? = true),
-			Swagger.JsonField("value", Swagger.JsonType(None, "boolean"), isRequired_? = true)
-		), isArray_? = isArray_?)
-
-		def sub(isArray_? : Boolean = false) = Swagger.JsonType(Some("Namespace.Sub"), "object", fields = Seq(
-			Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired_? = true),
-			Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"))
-		), isArray_? = isArray_?)
-
-	}
-
-	describe("SwaggerReflection") {
-
-		describe("_reflectField") {
-
-			val tpe = typeOf[Test]
-
-			def call(field: String): Swagger.JsonField = {
-				val fields = tpe.decls.filter(_.isPublic)
-					.filter(_.isTerm).map(_.asTerm)
-					.filter(_.isGetter)
-				val fld = fields.filter(_.name.toString == field).head
-				SwaggerReflection._reflectField(fld)
-			}
-
-			describe("Simple types") {
-				it("Int") {
-					assertResult(Swagger.JsonField("int", jsonType.int(), isRequired_? = true)) {
-						call("int")
-					}
-				}
-
-				it("Long") {
-					assertResult(Swagger.JsonField("long", jsonType.long(), isRequired_? = true)) {
-						call("long")
-					}
-				}
-
-				it("Float") {
-					assertResult(Swagger.JsonField("float", jsonType.float(), isRequired_? = true)) {
-						call("float")
-					}
-				}
-
-				it("Double") {
-					assertResult(Swagger.JsonField("double", jsonType.double(), isRequired_? = true)) {
-						call("double")
-					}
-				}
-
-				it("String") {
-					assertResult(Swagger.JsonField("string", jsonType.string(), isRequired_? = true)) {
-						call("string")
-					}
-				}
-
-				it("Boolean") {
-					assertResult(Swagger.JsonField("boolean", jsonType.boolean(), isRequired_? = true)) {
-						call("boolean")
-					}
-				}
-
-			}
-
-			describe("Optional simple types") {
-				it("Int") {
-					assertResult(Swagger.JsonField("opInt", jsonType.int())) {
-						call("opInt")
-					}
-				}
-
-				it("Long") {
-					assertResult(Swagger.JsonField("opLong", jsonType.long())) {
-						call("opLong")
-					}
-				}
-
-				it("Float") {
-					assertResult(Swagger.JsonField("opFloat", jsonType.float())) {
-						call("opFloat")
-					}
-				}
-
-				it("Double") {
-					assertResult(Swagger.JsonField("opDouble", jsonType.double())) {
-						call("opDouble")
-					}
-				}
-
-				it("String") {
-					assertResult(Swagger.JsonField("opString", jsonType.string())) {
-						call("opString")
-					}
-				}
-
-				it("Boolean") {
-					assertResult(Swagger.JsonField("opBoolean", jsonType.boolean())) {
-						call("opBoolean")
-					}
-				}
-
-			}
-
-			describe("Simple arrays") {
-				it("Seq") {
-					assertResult(Swagger.JsonField("arrInt", jsonType.int(true), isRequired_? = true)) {
-						call("arrInt")
-					}
-				}
-
-				it("List") {
-					assertResult(Swagger.JsonField("arrLong", jsonType.long(true), isRequired_? = true)) {
-						call("arrLong")
-					}
-				}
-
-				it("Array") {
-					assertResult(Swagger.JsonField("arrFloat", jsonType.float(true), isRequired_? = true)) {
-						call("arrFloat")
-					}
-				}
-
-				it("Set") {
-					assertResult(Swagger.JsonField("arrDouble", jsonType.double(true), isRequired_? = true)) {
-						call("arrDouble")
-					}
-				}
-
-			}
-
-			describe("Case classes") {
-				it("Sub1") {
-					assertResult(Swagger.JsonField("sub", jsonType.sub1(), isRequired_? = true)) {
-						call("sub")
-					}
-				}
-			}
-
-			describe("Optional case classes") {
-				it("Sub2") {
-					assertResult(Swagger.JsonField("opSub", jsonType.sub2())) {
-						call("opSub")
-					}
-				}
-
-			}
-
-			describe("Case classes arrays") {
-				it("Seq") {
-					assertResult(Swagger.JsonField("arrSub1", jsonType.sub1(true), isRequired_? = true)) {
-						call("arrSub1")
-					}
-				}
-
-				it("List") {
-					assertResult(Swagger.JsonField("arrSub2", jsonType.sub2(true), isRequired_? = true)) {
-						call("arrSub2")
-					}
-				}
-
-			}
-		}
-
-		describe("_reflectTypeFormat") {
-
-			def call(tpe: Type) = SwaggerReflection._reflectTypeFormat(tpe)
-
-			describe("Simple types") {
-				it("Int") {
-					assertResult((None, "integer", "int32")) {
-						call(typeOf[Int])
-					}
-				}
-
-				it("Long") {
-					assertResult((None, "integer", "int64")) {
-						call(typeOf[Long])
-					}
-				}
-
-				it("Float") {
-					assertResult((None, "number", "float")) {
-						call(typeOf[Float])
-					}
-				}
-
-				it("Double") {
-					assertResult((None, "number", "double")) {
-						call(typeOf[Double])
-					}
-				}
-
-				it("String") {
-					assertResult((None, "string", "")) {
-						call(typeOf[String])
-					}
-				}
-
-				it("Boolean") {
-					assertResult((None, "boolean", "")) {
-						call(typeOf[Boolean])
-					}
-				}
-
-			}
-
-			describe("Case classes") {
-				it("Sub1") {
-					assertResult((Some("Sub1"), "object", "")) {
-						call(typeOf[Sub1])
-					}
-				}
-
-				it("Sub2") {
-					assertResult((Some("Sub2"), "object", "")) {
-						call(typeOf[Sub2])
-					}
-				}
-
-				it("Namespace.Sub") {
-					assertResult((Some("Namespace.Sub"), "object", "")) {
-						call(typeOf[Namespace.Sub])
-					}
-				}
-			}
-
-		}
-
-		describe("isArrayType_?") {
-			def call(tpe: Type) = SwaggerReflection.isArrayType_?(tpe)
-
-			it("Seq") {
-				assert(call(typeOf[Seq[String]]))
-				assert(call(typeOf[Seq[Int]]))
-				assert(call(typeOf[Seq[(Int, Boolean)]]))
-			}
-
-			it("List") {
-				assert(call(typeOf[List[Float]]))
-				assert(call(typeOf[List[Boolean]]))
-				assert(call(typeOf[List[Sub1]]))
-			}
-
-			it("Array") {
-				assert(call(typeOf[Array[Long]]))
-				assert(call(typeOf[Array[String]]))
-				assert(call(typeOf[Array[Sub2]]))
-			}
-
-			it("Set") {
-				assert(call(typeOf[Set[Long]]))
-				assert(call(typeOf[Set[String]]))
-				assert(call(typeOf[Set[Namespace.Sub]]))
-			}
-		}
-
-		describe("reflect") {
-			def call(tpe: Type) = SwaggerReflection.reflect(tpe)
-
-			describe("Simple Types") {
-				it("Int") {
-					assertResult(jsonType.int()) {
-						call(typeOf[Int])
-					}
-				}
-
-				it("Long") {
-					assertResult(jsonType.long()) {
-						call(typeOf[Long])
-					}
-				}
-
-				it("Float") {
-					assertResult(jsonType.float()) {
-						call(typeOf[Float])
-					}
-				}
-
-				it("Double") {
-					assertResult(jsonType.double()) {
-						call(typeOf[Double])
-					}
-				}
-
-				it("String") {
-					assertResult(jsonType.string()) {
-						call(typeOf[String])
-					}
-				}
-
-				it("Boolean") {
-					assertResult(jsonType.boolean()) {
-						call(typeOf[Boolean])
-					}
-				}
-
-			}
-
-			describe("Simple Arrays") {
-				it("Seq") {
-					assertResult(jsonType.int(true)) {
-						call(typeOf[Seq[Int]])
-					}
-				}
-
-				it("List") {
-					assertResult(jsonType.long(true)) {
-						call(typeOf[List[Long]])
-					}
-				}
-
-				it("Array") {
-					assertResult(jsonType.float(true)) {
-						call(typeOf[Array[Float]])
-					}
-				}
-
-				it("Set") {
-					assertResult(jsonType.double(true)) {
-						call(typeOf[Set[Double]])
-					}
-				}
-
-			}
-
-			describe("Case Classes") {
-				it("Sub1") {
-					assertResult(jsonType.sub1()) {
-						call(typeOf[Sub1])
-					}
-				}
-				it("Sub2") {
-					assertResult(jsonType.sub2()) {
-						call(typeOf[Sub2])
-					}
-				}
-				it("Namespace.Sub") {
-					assertResult(jsonType.sub()) {
-						call(typeOf[Namespace.Sub])
-					}
-				}
-			}
-
-			describe("Case Classes Arrays") {
-				it("Seq") {
-					assertResult(jsonType.sub1(true)) {
-						call(typeOf[Seq[Sub1]])
-					}
-				}
-
-				it("List") {
-					assertResult(jsonType.sub2(true)) {
-						call(typeOf[List[Sub2]])
-					}
-				}
-
-				it("Array") {
-					assertResult(jsonType.sub(true)) {
-						call(typeOf[Array[Namespace.Sub]])
-					}
-				}
-
-				it("Set") {
-					assertResult(jsonType.sub(true)) {
-						call(typeOf[Set[Namespace.Sub]])
-					}
-				}
-
-			}
-		}
-
-	}
+  object jsonType {
+    def int(isArray_? : Boolean = false) = Swagger.JsonType(None, "integer", "int32", isArray_? = isArray_?)
+
+    def long(isArray_? : Boolean = false) = Swagger.JsonType(None, "integer", "int64", isArray_? = isArray_?)
+
+    def float(isArray_? : Boolean = false) = Swagger.JsonType(None, "number", "float", isArray_? = isArray_?)
+
+    def double(isArray_? : Boolean = false) = Swagger.JsonType(None, "number", "double", isArray_? = isArray_?)
+
+    def string(isArray_? : Boolean = false) = Swagger.JsonType(None, "string", isArray_? = isArray_?)
+
+    def boolean(isArray_? : Boolean = false) = Swagger.JsonType(None, "boolean", isArray_? = isArray_?)
+
+    def sub1(isArray_? : Boolean = false) = Swagger.JsonType(Some("Sub1"), "object", fields = Seq(
+      Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired_? = true),
+      Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"), isRequired_? = true)
+    ), isArray_? = isArray_?)
+
+    def sub2(isArray_? : Boolean = false) = Swagger.JsonType(Some("Sub2"), "object", fields = Seq(
+      Swagger.JsonField("key", Swagger.JsonType(None, "string"), isRequired_? = true),
+      Swagger.JsonField("value", Swagger.JsonType(None, "boolean"), isRequired_? = true)
+    ), isArray_? = isArray_?)
+
+    def sub(isArray_? : Boolean = false) = Swagger.JsonType(Some("Namespace.Sub"), "object", fields = Seq(
+      Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired_? = true),
+      Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"))
+    ), isArray_? = isArray_?)
+
+  }
+
+  describe("SwaggerReflection") {
+
+    describe("_reflectField") {
+
+      val tpe = typeOf[Test]
+
+      def call(field: String): Swagger.JsonField = {
+        val fields = tpe.decls.filter(_.isPublic)
+          .filter(_.isTerm).map(_.asTerm)
+          .filter(_.isGetter)
+        val fld = fields.filter(_.name.toString == field).head
+        SwaggerReflection._reflectField(fld)
+      }
+
+      describe("Simple types") {
+        it("Int") {
+          assertResult(Swagger.JsonField("int", jsonType.int(), isRequired_? = true)) {
+            call("int")
+          }
+        }
+
+        it("Long") {
+          assertResult(Swagger.JsonField("long", jsonType.long(), isRequired_? = true)) {
+            call("long")
+          }
+        }
+
+        it("Float") {
+          assertResult(Swagger.JsonField("float", jsonType.float(), isRequired_? = true)) {
+            call("float")
+          }
+        }
+
+        it("Double") {
+          assertResult(Swagger.JsonField("double", jsonType.double(), isRequired_? = true)) {
+            call("double")
+          }
+        }
+
+        it("String") {
+          assertResult(Swagger.JsonField("string", jsonType.string(), isRequired_? = true)) {
+            call("string")
+          }
+        }
+
+        it("Boolean") {
+          assertResult(Swagger.JsonField("boolean", jsonType.boolean(), isRequired_? = true)) {
+            call("boolean")
+          }
+        }
+
+      }
+
+      describe("Optional simple types") {
+        it("Int") {
+          assertResult(Swagger.JsonField("opInt", jsonType.int())) {
+            call("opInt")
+          }
+        }
+
+        it("Long") {
+          assertResult(Swagger.JsonField("opLong", jsonType.long())) {
+            call("opLong")
+          }
+        }
+
+        it("Float") {
+          assertResult(Swagger.JsonField("opFloat", jsonType.float())) {
+            call("opFloat")
+          }
+        }
+
+        it("Double") {
+          assertResult(Swagger.JsonField("opDouble", jsonType.double())) {
+            call("opDouble")
+          }
+        }
+
+        it("String") {
+          assertResult(Swagger.JsonField("opString", jsonType.string())) {
+            call("opString")
+          }
+        }
+
+        it("Boolean") {
+          assertResult(Swagger.JsonField("opBoolean", jsonType.boolean())) {
+            call("opBoolean")
+          }
+        }
+
+      }
+
+      describe("Simple arrays") {
+        it("Seq") {
+          assertResult(Swagger.JsonField("arrInt", jsonType.int(true), isRequired_? = true)) {
+            call("arrInt")
+          }
+        }
+
+        it("List") {
+          assertResult(Swagger.JsonField("arrLong", jsonType.long(true), isRequired_? = true)) {
+            call("arrLong")
+          }
+        }
+
+        it("Array") {
+          assertResult(Swagger.JsonField("arrFloat", jsonType.float(true), isRequired_? = true)) {
+            call("arrFloat")
+          }
+        }
+
+        it("Set") {
+          assertResult(Swagger.JsonField("arrDouble", jsonType.double(true), isRequired_? = true)) {
+            call("arrDouble")
+          }
+        }
+
+      }
+
+      describe("Case classes") {
+        it("Sub1") {
+          assertResult(Swagger.JsonField("sub", jsonType.sub1(), isRequired_? = true)) {
+            call("sub")
+          }
+        }
+      }
+
+      describe("Optional case classes") {
+        it("Sub2") {
+          assertResult(Swagger.JsonField("opSub", jsonType.sub2())) {
+            call("opSub")
+          }
+        }
+
+      }
+
+      describe("Case classes arrays") {
+        it("Seq") {
+          assertResult(Swagger.JsonField("arrSub1", jsonType.sub1(true), isRequired_? = true)) {
+            call("arrSub1")
+          }
+        }
+
+        it("List") {
+          assertResult(Swagger.JsonField("arrSub2", jsonType.sub2(true), isRequired_? = true)) {
+            call("arrSub2")
+          }
+        }
+
+      }
+    }
+
+    describe("_reflectTypeFormat") {
+
+      def call(tpe: Type) = SwaggerReflection._reflectTypeFormat(tpe)
+
+      describe("Simple types") {
+        it("Int") {
+          assertResult((None, "integer", "int32")) {
+            call(typeOf[Int])
+          }
+        }
+
+        it("Long") {
+          assertResult((None, "integer", "int64")) {
+            call(typeOf[Long])
+          }
+        }
+
+        it("Float") {
+          assertResult((None, "number", "float")) {
+            call(typeOf[Float])
+          }
+        }
+
+        it("Double") {
+          assertResult((None, "number", "double")) {
+            call(typeOf[Double])
+          }
+        }
+
+        it("String") {
+          assertResult((None, "string", "")) {
+            call(typeOf[String])
+          }
+        }
+
+        it("Boolean") {
+          assertResult((None, "boolean", "")) {
+            call(typeOf[Boolean])
+          }
+        }
+
+      }
+
+      describe("Case classes") {
+        it("Sub1") {
+          assertResult((Some("Sub1"), "object", "")) {
+            call(typeOf[Sub1])
+          }
+        }
+
+        it("Sub2") {
+          assertResult((Some("Sub2"), "object", "")) {
+            call(typeOf[Sub2])
+          }
+        }
+
+        it("Namespace.Sub") {
+          assertResult((Some("Namespace.Sub"), "object", "")) {
+            call(typeOf[Namespace.Sub])
+          }
+        }
+      }
+
+    }
+
+    describe("isArrayType_?") {
+      def call(tpe: Type) = SwaggerReflection.isArrayType_?(tpe)
+
+      it("Seq") {
+        assert(call(typeOf[Seq[String]]))
+        assert(call(typeOf[Seq[Int]]))
+        assert(call(typeOf[Seq[(Int, Boolean)]]))
+      }
+
+      it("List") {
+        assert(call(typeOf[List[Float]]))
+        assert(call(typeOf[List[Boolean]]))
+        assert(call(typeOf[List[Sub1]]))
+      }
+
+      it("Array") {
+        assert(call(typeOf[Array[Long]]))
+        assert(call(typeOf[Array[String]]))
+        assert(call(typeOf[Array[Sub2]]))
+      }
+
+      it("Set") {
+        assert(call(typeOf[Set[Long]]))
+        assert(call(typeOf[Set[String]]))
+        assert(call(typeOf[Set[Namespace.Sub]]))
+      }
+    }
+
+    describe("reflect") {
+      def call(tpe: Type) = SwaggerReflection.reflect(tpe)
+
+      describe("Simple Types") {
+        it("Int") {
+          assertResult(jsonType.int()) {
+            call(typeOf[Int])
+          }
+        }
+
+        it("Long") {
+          assertResult(jsonType.long()) {
+            call(typeOf[Long])
+          }
+        }
+
+        it("Float") {
+          assertResult(jsonType.float()) {
+            call(typeOf[Float])
+          }
+        }
+
+        it("Double") {
+          assertResult(jsonType.double()) {
+            call(typeOf[Double])
+          }
+        }
+
+        it("String") {
+          assertResult(jsonType.string()) {
+            call(typeOf[String])
+          }
+        }
+
+        it("Boolean") {
+          assertResult(jsonType.boolean()) {
+            call(typeOf[Boolean])
+          }
+        }
+
+      }
+
+      describe("Simple Arrays") {
+        it("Seq") {
+          assertResult(jsonType.int(true)) {
+            call(typeOf[Seq[Int]])
+          }
+        }
+
+        it("List") {
+          assertResult(jsonType.long(true)) {
+            call(typeOf[List[Long]])
+          }
+        }
+
+        it("Array") {
+          assertResult(jsonType.float(true)) {
+            call(typeOf[Array[Float]])
+          }
+        }
+
+        it("Set") {
+          assertResult(jsonType.double(true)) {
+            call(typeOf[Set[Double]])
+          }
+        }
+
+      }
+
+      describe("Case Classes") {
+        it("Sub1") {
+          assertResult(jsonType.sub1()) {
+            call(typeOf[Sub1])
+          }
+        }
+        it("Sub2") {
+          assertResult(jsonType.sub2()) {
+            call(typeOf[Sub2])
+          }
+        }
+        it("Namespace.Sub") {
+          assertResult(jsonType.sub()) {
+            call(typeOf[Namespace.Sub])
+          }
+        }
+      }
+
+      describe("Case Classes Arrays") {
+        it("Seq") {
+          assertResult(jsonType.sub1(true)) {
+            call(typeOf[Seq[Sub1]])
+          }
+        }
+
+        it("List") {
+          assertResult(jsonType.sub2(true)) {
+            call(typeOf[List[Sub2]])
+          }
+        }
+
+        it("Array") {
+          assertResult(jsonType.sub(true)) {
+            call(typeOf[Array[Namespace.Sub]])
+          }
+        }
+
+        it("Set") {
+          assertResult(jsonType.sub(true)) {
+            call(typeOf[Set[Namespace.Sub]])
+          }
+        }
+
+      }
+    }
+
+  }
 
 }
 


### PR DESCRIPTION
This patch allows to document JSON models from case classes with Swagger like this example:

```scala
package quickstart.action

import java.util.Date

import xitrum.FutureAction
import xitrum.annotation.{POST, Swagger}
import xitrum.util.SeriDeseri

@POST("api/test")
@Swagger(
	Swagger.JsonBody("request", "This is request model", Test.RequestType),
	Swagger.Response(200, "Success", Some(Test.ResponseType)),
	Swagger.Response(201, "Success", Some(Test.ResponseArrayType)),
	Swagger.Response(404, "Not found")
)
class Test extends FutureAction {
	override def execute(): Unit = {
		SeriDeseri.fromJValue[Test.Request](requestContentJValue) match {
			case Some(req) => // do something useful
			case None => // reply 404 or something
		}
	}
}

object Test {

	case class Sub(subValue: Option[Int])

	case class Response(value: String, sub: Sub)

	case class Request(integer: Int,
	                   long: Long,
	                   float: Float,
	                   double: Double,
	                   string: String,
	                   boolean: Boolean,
	                   dateTime: Date,
	                   optional: Option[String],
	                   list: List[String],
	                   seq: Seq[Sub],
	                   obj: Sub
	                  )

	val RequestType = Swagger.arrayOf[Request]
	val ResponseType = Swagger.valueOf[Response]
	val ResponseArrayType = Swagger.arrayOf[Response]
}
```

And this code will produce following swagger.json
```json
{
  "swagger" : "2.0",
  "info" : {
    "title" : "APIs documented by Swagger",
    "version" : "1.0-SNAPSHOT"
  },
  "basePath" : "/",
  "paths" : {
    "/api/test" : {
      "post" : {
        "operationId" : "test",
        "parameters" : [ {
          "name" : "request",
          "in" : "body",
          "description" : "This is request model",
          "required" : true,
          "schema" : {
            "type" : "array",
            "items" : {
              "$ref" : "#/definitions/Test.Request"
            }
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "Success",
            "schema" : {
              "$ref" : "#/definitions/Test.Response"
            }
          },
          "201" : {
            "description" : "Success",
            "schema" : {
              "type" : "array",
              "items" : {
                "$ref" : "#/definitions/Test.Response"
              }
            }
          },
          "404" : {
            "description" : "Not found"
          }
        }
      }
    }
  },
  "definitions" : {
    "Test.Request" : {
      "type" : "object",
      "properties" : {
        "integer" : {
          "type" : "integer",
          "format" : "int32"
        },
        "long" : {
          "type" : "integer",
          "format" : "int64"
        },
        "float" : {
          "type" : "number",
          "format" : "float"
        },
        "double" : {
          "type" : "number",
          "format" : "double"
        },
        "string" : {
          "type" : "string",
          "format" : ""
        },
        "boolean" : {
          "type" : "boolean",
          "format" : ""
        },
        "dateTime" : {
          "type" : "string",
          "format" : "date-time"
        },
        "optional" : {
          "type" : "string",
          "format" : ""
        },
        "list" : {
          "type" : "array",
          "items" : {
            "type" : "string",
            "format" : ""
          }
        },
        "seq" : {
          "type" : "array",
          "items" : {
            "$ref" : "#/definitions/Test.Sub"
          }
        },
        "obj" : {
          "$ref" : "#/definitions/Test.Sub"
        }
      },
      "required" : [ "integer", "long", "float", "double", "string", "boolean", "dateTime", "list", "seq", "obj" ]
    },
    "Test.Sub" : {
      "type" : "object",
      "properties" : {
        "subValue" : {
          "type" : "integer",
          "format" : "int32"
        }
      }
    },
    "Test.Response" : {
      "type" : "object",
      "properties" : {
        "value" : {
          "type" : "string",
          "format" : ""
        },
        "sub" : {
          "$ref" : "#/definitions/Test.Sub"
        }
      },
      "required" : [ "value", "sub" ]
    }
  }
}
```

You may want to load that json to [Swagger Online Editor](http://editor.swagger.io/) to check how the documentation looks like.

This patch supports simple case classes as models (not sure about inheritance and other advanced features), `Seq`, `List`, `Set` as array types, `Option` for non-mandatory fields.