### PR TITLE
#675 Improve range header handling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+3.18.16:
+
+* `#675 <https://github.com/xitrum-framework/xitrum/issues/675>`_
+  Invalid range request causes increase in CPU usage as 100%
+
 3.18.15:
 
 * `#674 <https://github.com/xitrum-framework/xitrum/issues/674>`_


### PR DESCRIPTION
Patch for #675 

```
# with invalid header, it should response 200 with whole content

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: '
HTTP/1.1 200 OK
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:28:14 GMT
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes='
HTTP/1.1 200 OK
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:28:34 GMT
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=-'
HTTP/1.1 200 OK
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:52:05 GMT
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=--'
HTTP/1.1 200 OK
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:29:13 GMT
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=0--1'
HTTP/1.1 200 OK
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:24 GMT
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=10-5'
HTTP/1.1 200 OK
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:58:43 GMT
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

------------

# with valid header(last-byte-pos value is absent), it should response 206 with partial content

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=0'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:28:37 GMT
accept-ranges: bytes
content-range: bytes 0-1048575/1048576
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg


$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=0-'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:28:43 GMT
accept-ranges: bytes
content-range: bytes 0-1048575/1048576
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg


$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=1'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:42:41 GMT
accept-ranges: bytes
content-range: bytes 1-1048575/1048576
content-length: 1048575
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg


$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=1048574'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:00 GMT
accept-ranges: bytes
content-range: bytes 1048574-1048575/1048576
content-length: 2
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=1048575'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:02 GMT
accept-ranges: bytes
content-range: bytes 1048575-1048575/1048576
content-length: 1
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

# with valid header(last-byte-pos value is present), it should response 206 with partial content

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=0-0'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:16 GMT
accept-ranges: bytes
content-range: bytes 0-0/1048576
content-length: 1
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=0-1'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:12 GMT
accept-ranges: bytes
content-range: bytes 0-1/1048576
content-length: 2
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=0-1048574'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:39 GMT
accept-ranges: bytes
content-range: bytes 0-1048574/1048576
content-length: 1048575
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=0-1048575'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:42 GMT
accept-ranges: bytes
content-range: bytes 0-1048575/1048576
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

# If the last-byte-pos value is absent, or if the value is greater than or equal to the current length of the entity-body, last-byte-pos is taken to be equal to one less than the current length

$ curl -D - -s  -o /dev/null http://localhost:8000/dummy.jpg -H 'Range: bytes=0-1048576'
HTTP/1.1 206 Partial Content
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:45 GMT
accept-ranges: bytes
content-range: bytes 0-1048575/1048576
content-length: 1048576
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg

# If first-byte-pos value greater than the current length of the selected resource, it should response 416 without content

HTTP/1.1 416 Requested Range Not Satisfiable
connection: keep-alive
cache-control: public, max-age=31536000
access-control-max-age: 31536000
expires: Fri, 14 Feb 2020 06:43:05 GMT
accept-ranges: bytes
content-range: bytes */1048576
content-length: 0
last-modified: Thu, 14 Feb 2019 01:20:46 GMT
content-type: image/jpeg
```