### PR TITLE
Explicitly provide no session

### DIFF
--- a/src/test/scala/xitrum/action/SessionTest.scala
+++ b/src/test/scala/xitrum/action/SessionTest.scala
@@ -1,0 +1,66 @@
+package xitrum.action
+
+import org.asynchttpclient.Dsl.asyncHttpClient
+import org.scalatest._
+import xitrum.annotation.GET
+import xitrum.scope.session.TransientSession
+import xitrum.{Action, Log, Server}
+
+import scala.collection.JavaConverters._
+
+@GET("/session")
+class SessionAccessAction extends Action {
+  def execute(): Unit = {
+    if (param[Boolean]("access")) {
+      session.put("Hello", "World")
+    }
+    respond()
+  }
+}
+
+@GET("/sessionless")
+class SessionlessAction extends Action with TransientSession {
+  def execute(): Unit = {
+    if (param[Boolean]("access")) {
+      session.put("Hello", "World")
+    }
+    respond()
+  }
+}
+
+// sessions are retrieved and stored only if the map is accessed (see SessionEnv)
+class SessionTest extends FlatSpec with BeforeAndAfter with Log {
+
+  private val basePath = "http://127.0.0.1:8000/my_site"
+  private val client = asyncHttpClient()
+
+  behavior of "Session"
+
+  before {
+    Server.start()
+  }
+
+  after {
+    Server.stop()
+  }
+
+  "Accessing session" should "provide a session if not transient" in {
+    val response = client.prepareGet(basePath + "/session?access=true").execute().get()
+    assert(response.getCookies.asScala.exists(_.name == "_session"))
+  }
+
+  it should "not provide a session if transient" in {
+    val response = client.prepareGet(basePath + "/sessionless?access=true").execute().get()
+    assert(!response.getCookies.asScala.exists(_.name == "_session"))
+  }
+
+  "Not accessing session" should "provide no session if not transient" in {
+    val response = client.prepareGet(basePath + "/session?access=false").execute().get()
+    assert(!response.getCookies.asScala.exists(_.name == "_session"))
+  }
+
+  it should "provide no session if transient" in {
+    val response = client.prepareGet(basePath + "/sessionless?access=false").execute().get()
+    assert(!response.getCookies.asScala.exists(_.name == "_session"))
+  }
+}


### PR DESCRIPTION
We would like to explicitly ensure that a session is not retrieved or stored. 

We use filters and store data on session (for authentication and application state) but do not always have recipients that use sessions. We would not want to hit max user sessions in hazelcast and have our session users logged out because we've had too many users that dont make use of the sessions. We're storing data in hazelcast unnecessarily as they never return with the same session.