### PR TITLE
Swagger documentation for BodyParam and Responses with JSON models generated from case classes by reflections (squashed)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=false
+indent_style=space
+indent_size=2
+

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,6 @@
 [*]
 charset=utf-8
 end_of_line=lf
-insert_final_newline=false
+insert_final_newline=true
 indent_style=space
 indent_size=2
-

--- a/src/main/scala/xitrum/annotation/Swagger.scala
+++ b/src/main/scala/xitrum/annotation/Swagger.scala
@@ -1,5 +1,6 @@
 package xitrum.annotation
 
+import scala.reflect.runtime.universe.{TypeTag, symbolOf}
 import scala.annotation.StaticAnnotation
 
 case class Swagger(swaggerArgs: SwaggerTypes.SwaggerArg*) extends StaticAnnotation
@@ -34,6 +35,7 @@ object SwaggerTypes {
   sealed trait SwaggerDateTimeParam
   sealed trait SwaggerPasswordParam
   sealed trait SwaggerFileParam
+  sealed trait SwaggerJsonParam
 }
 
 /** See: https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md */
@@ -45,12 +47,11 @@ object Swagger {
   case class Description(desc: String) extends SwaggerArg
   case class ExternalDocs(url: String, desc: String = "") extends SwaggerArg
   case class OperationId(id: String) extends SwaggerArg
-
   case class Consumes(contentTypes: String*) extends SwaggerArg
   case class Produces(contentTypes: String*) extends SwaggerArg
 
   /** Can use this multiple times at an action. */
-  case class Response(code: Int = 0, desc: String) extends SwaggerArg
+  case class Response(code: Int = 0, desc: String, tpeOpt: Option[JsonType] = None) extends SwaggerArg
 
   case class Schemes(schemes: String*) extends SwaggerArg
   case object Deprecated extends SwaggerArg
@@ -117,6 +118,7 @@ object Swagger {
   case class DateBody    (name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateParam
   case class DateTimeBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerDateTimeParam
   case class PasswordBody(name: String, desc: String = "") extends SwaggerParamArg with SwaggerBodyParam with SwaggerPasswordParam
+  case class JsonBody    (name: String, desc: String = "", tpe: JsonType) extends SwaggerParamArg with SwaggerBodyParam with SwaggerJsonParam
 
   //----------------------------------------------------------------------------
 
@@ -180,4 +182,81 @@ object Swagger {
   case class OptDateBody    (name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateParam
   case class OptDateTimeBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerDateTimeParam
   case class OptPasswordBody(name: String, desc: String = "") extends SwaggerOptParamArg with SwaggerBodyParam with SwaggerPasswordParam
+
+  // Types definitions
+
+  /**
+    * Structure for building object fields documentation
+    *
+    * @param name         field name
+    * @param tpe          field type
+    * @param isRequired   if true means that field is required
+    */
+  case class JsonField(name: String, tpe: JsonType, isRequired : Boolean = false)
+
+  /**
+    * Structure for building object types documentation
+    *
+    * @param name      type name (actual for `tpe` == "object" only)
+    * @param tpe       type in Swagger terms @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+    * @param format    additional Swagger type definition
+    * @param isArray   true is marking the type as array of `tpe` items
+    * @param fields    list of `object` fields (actual for `tpe` == "object" only)
+    */
+  case class JsonType(name: Option[String], tpe: String, format: String = "", var isArray : Boolean = false, var fields: Seq[JsonField] = Seq()) {
+
+    def isArray(value: Boolean): JsonType = {
+      isArray = value
+      this
+    }
+  }
+
+  object JsonType {
+
+    object tpe {
+      val integer = "integer"
+      val number = "number"
+      val string = "string"
+      val boolean = "boolean"
+      val obj = "object"
+      val file = "file"
+    }
+
+    object fmt {
+      val none = ""
+      val int32 = "int32"
+      val int64 = "int64"
+      val float = "float"
+      val double = "double"
+      val dateTime = "date-time"
+      val byte = "byte"
+      val binary = "binary"
+      val date = "date"
+      val password = "password"
+    }
+
+  }
+
+  /**
+    * Builds the Swagger type definition structure for documenting API requests/responses represented by single objects
+    *
+    * Usage:
+    * create some `case class Response(value: String)` for your API response
+    * create somewhere type definition `val swagger = Swagger.valueOf[Response]`
+    * use that type definition to document your Swagger API `Swagger.Response(200, "Success", Some(swagger))`
+    */
+  def valueOf[T](implicit tag: TypeTag[T]): JsonType = {
+    val tpe = tag.tpe
+    assert(tpe.typeSymbol != symbolOf[Option[_]], "Root types can not be optional, optional parameters should be implemented with Opt version of annotations")
+    assert(!SwaggerReflection.isArrayType(tpe), "Root types should not be of collection types, to specify the array type use `arrayOf` method instead")
+    SwaggerReflection.reflect(tpe)
+  }
+
+  /**
+    * Builds the Swagger type definition structure for documenting API requests/responses represented by arrays of specific object type
+    */
+  def arrayOf[T](implicit tag: TypeTag[T]): JsonType = {
+    valueOf(tag).isArray(true)
+  }
+
 }

--- a/src/main/scala/xitrum/annotation/Swagger.scala
+++ b/src/main/scala/xitrum/annotation/Swagger.scala
@@ -204,7 +204,6 @@ object Swagger {
     * @param fields    list of `object` fields (actual for `tpe` == "object" only)
     */
   case class JsonType(name: Option[String], tpe: String, format: String = "", var isArray : Boolean = false, var fields: Seq[JsonField] = Seq()) {
-
     def isArray(value: Boolean): JsonType = {
       isArray = value
       this
@@ -212,7 +211,6 @@ object Swagger {
   }
 
   object JsonType {
-
     object tpe {
       val integer = "integer"
       val number = "number"
@@ -234,7 +232,6 @@ object Swagger {
       val date = "date"
       val password = "password"
     }
-
   }
 
   /**
@@ -258,5 +255,4 @@ object Swagger {
   def arrayOf[T](implicit tag: TypeTag[T]): JsonType = {
     valueOf(tag).isArray(true)
   }
-
 }

--- a/src/main/scala/xitrum/annotation/SwaggerReflection.scala
+++ b/src/main/scala/xitrum/annotation/SwaggerReflection.scala
@@ -6,7 +6,6 @@ import scala.reflect.runtime.universe._
  * Utility functions to reflect scala case classes to structure that can be rendered to Swagger documentation
  */
 object SwaggerReflection {
-
   private val _arraySymbols = Set[Name](
     symbolOf[Seq[_]].name,
     symbolOf[Set[_]].name,
@@ -15,7 +14,6 @@ object SwaggerReflection {
   )
 
   def isArrayType(tpe: Type): Boolean = _arraySymbols.contains(tpe.typeSymbol.name)
-
 
   private[annotation] def reflectField(fld: TermSymbol): Swagger.JsonField = {
     val retType = fld.asMethod.returnType
@@ -36,7 +34,7 @@ object SwaggerReflection {
       var pack = tpe.typeSymbol.owner
       while (!pack.isPackage)
         pack = pack.owner
-      (Some(tpe.typeSymbol.fullName.toString.substring(pack.fullName.length + 1)), Swagger.JsonType.tpe.obj, Swagger.JsonType.fmt.none)
+      (Some(tpe.typeSymbol.fullName.substring(pack.fullName.length + 1)), Swagger.JsonType.tpe.obj, Swagger.JsonType.fmt.none)
   }
 
   def reflect(tpe: Type): Swagger.JsonType = {
@@ -48,5 +46,4 @@ object SwaggerReflection {
     val (name, tipe, format) = reflectTypeFormat(tip)
     Swagger.JsonType(name, tipe, format, isTpeArray, fields)
   }
-
 }

--- a/src/main/scala/xitrum/annotation/SwaggerReflection.scala
+++ b/src/main/scala/xitrum/annotation/SwaggerReflection.scala
@@ -1,0 +1,52 @@
+package xitrum.annotation
+
+import scala.reflect.runtime.universe._
+
+/**
+ * Utility functions to reflect scala case classes to structure that can be rendered to Swagger documentation
+ */
+object SwaggerReflection {
+
+  private val _arraySymbols = Set[Name](
+    symbolOf[Seq[_]].name,
+    symbolOf[Set[_]].name,
+    symbolOf[List[_]].name,
+    symbolOf[Array[_]].name
+  )
+
+  def isArrayType(tpe: Type): Boolean = _arraySymbols.contains(tpe.typeSymbol.name)
+
+
+  private[annotation] def reflectField(fld: TermSymbol): Swagger.JsonField = {
+    val retType = fld.asMethod.returnType
+    val isRequired = retType.typeSymbol != symbolOf[Option[_]]
+    val tpe = if (isRequired) retType else retType.typeArgs.head
+    Swagger.JsonField(fld.name.toString, reflect(tpe), isRequired)
+  }
+
+  private[annotation] def reflectTypeFormat(tpe: Type): (Option[String], String, String) = tpe.typeSymbol match {
+    case t if t == definitions.IntClass => (None, Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32)
+    case t if t == definitions.LongClass => (None, Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64)
+    case t if t == definitions.FloatClass => (None, Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float)
+    case t if t == definitions.DoubleClass => (None, Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double)
+    case t if t == definitions.StringClass => (None, Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none)
+    case t if t == definitions.BooleanClass => (None, Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none)
+    case t if t == symbolOf[java.util.Date] => (None, Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime)
+    case _ =>
+      var pack = tpe.typeSymbol.owner
+      while (!pack.isPackage)
+        pack = pack.owner
+      (Some(tpe.typeSymbol.fullName.toString.substring(pack.fullName.length + 1)), Swagger.JsonType.tpe.obj, Swagger.JsonType.fmt.none)
+  }
+
+  def reflect(tpe: Type): Swagger.JsonType = {
+    val isTpeArray = isArrayType(tpe)
+    val tip = if (isTpeArray) tpe.typeArgs.head else tpe
+    val fields = tip.decls.filter(_.isPublic)
+      .filter(_.isTerm).map(_.asTerm)
+      .filter(_.isGetter).toList.map(reflectField)
+    val (name, tipe, format) = reflectTypeFormat(tip)
+    Swagger.JsonType(name, tipe, format, isTpeArray, fields)
+  }
+
+}

--- a/src/main/scala/xitrum/routing/SwaggerActions.scala
+++ b/src/main/scala/xitrum/routing/SwaggerActions.scala
@@ -6,11 +6,12 @@ import org.json4s.JField
 import org.json4s.JsonAST.{JString, JArray, JValue, JObject}
 import org.json4s.JsonDSL._
 import org.json4s.jackson.JsonMethods
-
 import xitrum.{FutureAction, Config}
 import xitrum.annotation.{First, GET, Swagger, SwaggerTypes}
+import xitrum.annotation.Swagger.JsonField
 
 import scala.collection.immutable.ListMap
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 @First
@@ -32,6 +33,7 @@ class SwaggerUi extends FutureAction {
 
 /** https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md */
 object SwaggerJson {
+
   import SwaggerTypes._
 
   private val SWAGGER_VERSION = "2.0"
@@ -45,8 +47,10 @@ object SwaggerJson {
 
   def json: String = prettyJson
 
+  private lazy val definitions = mutable.Map.empty[String, JValue]
+
   /** Maybe called multiple times in development mode when reloading routes. */
-  def reloadFromRoutes(): Unit = {
+  def reloadFromRoutes() {
     prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
   }
 
@@ -55,10 +59,11 @@ object SwaggerJson {
   private def getSwaggerObject: JValue = {
     val info     = ("title" -> "APIs documented by Swagger") ~ ("version" -> apiVersion)
     val basePath = if (Config.baseUrl.isEmpty) "/" else Config.baseUrl
-    ("swagger"  -> SWAGGER_VERSION) ~
-    ("info"     -> info) ~
-    ("basePath" -> basePath) ~
-    ("paths"    -> getPathsObject)
+    ("swagger"     -> SWAGGER_VERSION) ~
+    ("info"        -> info) ~
+    ("basePath"    -> basePath) ~
+    ("paths"       -> getPathsObject) ~
+    ("definitions" -> getDefinitionsObject)
   }
 
   private def getPathsObject: JValue = {
@@ -72,6 +77,10 @@ object SwaggerJson {
         (path, pathItem)
       }
     JObject(pathToPathItemObjects: _*)
+  }
+
+  private def getDefinitionsObject: JValue = {
+    JObject(definitions.toList: _*)
   }
 
   private def groupSwaggerRoutesByPath: Map[String, Seq[Route]] = {
@@ -203,6 +212,77 @@ object SwaggerJson {
     if (params.isEmpty) None else Some("parameters" -> JArray(params.toList))
   }
 
+  private def _objectField(field: JsonField): (String, JObject) = {
+    field.name -> _autoJsonType(field.tpe, asField = true)
+  }
+
+  private def _addObjectDefinition(tpe: Swagger.JsonType): Unit = {
+    if (tpe.tpe == Swagger.JsonType.tpe.obj) {
+      val key = tpe.name.get
+      if (!definitions.contains(key)) {
+        var definition = ("type" -> "object") ~
+          ("properties" -> JObject(tpe.fields.map(_objectField): _*))
+        val required = tpe.fields.filter(_.isRequired).map(_.name)
+        if (required.nonEmpty)
+          definition = definition ~
+            ("required" -> required)
+        definitions.put(key, definition)
+      }
+    }
+  }
+
+  private def _definitionPath(tpe: Swagger.JsonType): String = s"#/definitions/${tpe.name.get}"
+
+  private def _simpleType(tipe: String, format: String, withoutSchema : Boolean): JObject = {
+    val tpe = ("type" -> tipe) ~
+      ("format" -> format)
+    if (withoutSchema)
+      tpe
+    else "schema" -> tpe
+  }
+
+  private def _simpleArrayType(tipe: String, format: String, withoutSchema : Boolean): JObject = {
+    val tpe = ("type" -> "array") ~
+      ("items" -> _simpleType(tipe, format, withoutSchema = true))
+    if (withoutSchema)
+      tpe
+    else "schema" -> tpe
+  }
+
+  private def _objectArrayType(path: String, withoutSchema : Boolean): JObject = {
+    val tpe = ("type" -> "array") ~
+      ("items" -> ("$ref" -> path))
+    if (withoutSchema)
+      tpe
+    else "schema" -> tpe
+  }
+
+
+  private def _objectType(path: String, withoutSchema : Boolean): JObject = {
+    val tpe = "$ref" -> path
+    if (withoutSchema)
+      tpe
+    else "schema" -> tpe
+  }
+
+  private def _autoJsonType(tpe: Swagger.JsonType, asField : Boolean = false): JObject = {
+    _addObjectDefinition(tpe)
+    tpe.tpe match {
+      case Swagger.JsonType.tpe.obj =>
+        if (tpe.isArray) {
+          _objectArrayType(_definitionPath(tpe), asField)
+        } else {
+          _objectType(_definitionPath(tpe), asField)
+        }
+      case _ =>
+        if (tpe.isArray) {
+          _simpleArrayType(tpe.tpe, tpe.format, asField)
+        } else {
+          _simpleType(tpe.tpe, tpe.format, asField)
+        }
+    }
+  }
+
   private def getParameter(arg: SwaggerParamArg): JValue = {
     val location = arg match {
       case _: SwaggerPathParam   => "path"
@@ -214,35 +294,43 @@ object SwaggerJson {
 
     val required = !arg.isInstanceOf[SwaggerOptParamArg]
 
-    val (tipe, format) = arg match {
-      case _: SwaggerIntParam      => ("integer",  "int32")
-      case _: SwaggerLongParam     => ("integer",  "int64")
-      case _: SwaggerFloatParam    => ("number",  "float")
-      case _: SwaggerDoubleParam   => ("number",  "double")
-      case _: SwaggerStringParam   => ("string",  "")
-      case _: SwaggerByteParam     => ("string",  "byte")
-      case _: SwaggerBinaryParam   => ("string",  "binary")
-      case _: SwaggerBooleanParam  => ("boolean", "")
-      case _: SwaggerDateParam     => ("string",  "date")
-      case _: SwaggerDateTimeParam => ("string",  "date-time")
-      case _: SwaggerPasswordParam => ("string",  "password")
-      case _: SwaggerFileParam     => ("file",    "")
-    }
-
     ("name"        -> arg.name) ~
     ("in"          -> location) ~
     ("description" -> arg.desc) ~
     ("required"    -> required) ~
-    ("type"        -> tipe) ~
-    ("format"      -> format)
+    (arg match {
+      case _: SwaggerIntParam      => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32, withoutSchema = true)
+      case _: SwaggerLongParam     => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64, withoutSchema = true)
+      case _: SwaggerFloatParam    => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float, withoutSchema = true)
+      case _: SwaggerDoubleParam   => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double, withoutSchema = true)
+      case _: SwaggerStringParam   => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema = true)
+      case _: SwaggerByteParam     => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.byte, withoutSchema = true)
+      case _: SwaggerBinaryParam   => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.binary, withoutSchema = true)
+      case _: SwaggerBooleanParam  => _simpleType(Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none, withoutSchema = true)
+      case _: SwaggerDateParam     => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.date, withoutSchema = true)
+      case _: SwaggerDateTimeParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime, withoutSchema = true)
+      case _: SwaggerPasswordParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.password, withoutSchema = true)
+      case _: SwaggerFileParam     => _simpleType(Swagger.JsonType.tpe.file, Swagger.JsonType.fmt.none, withoutSchema = true)
+      case _: SwaggerJsonParam     => arg match {
+        case argJson: Swagger.JsonBody => _autoJsonType(argJson.tpe)
+        case _                         => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema = true)
+      }
+    })
   }
+
 
   private def getResponses(args: Seq[SwaggerArg]): Option[JField] = {
     val codeToDescs = args.filter(_.isInstanceOf[Swagger.Response]).map { arg =>
       val response = arg.asInstanceOf[Swagger.Response]
       val code = if (response.code <= 0) "default" else response.code.toString
       val desc = response.desc
-      code -> JObject("description" -> JString(desc))
+      var details = JObject("description" -> JString(desc))
+      response.tpeOpt match {
+        case Some(tpe) =>
+          details = details ~ _autoJsonType(tpe)
+        case None =>
+      }
+      code -> details
     }
     Some("responses" -> JObject(codeToDescs: _*))
   }

--- a/src/main/scala/xitrum/routing/SwaggerActions.scala
+++ b/src/main/scala/xitrum/routing/SwaggerActions.scala
@@ -50,7 +50,7 @@ object SwaggerJson {
   private lazy val definitions = mutable.Map.empty[String, JValue]
 
   /** Maybe called multiple times in development mode when reloading routes. */
-  def reloadFromRoutes() {
+  def reloadFromRoutes(): Unit = {
     prettyJson = JsonMethods.pretty(JsonMethods.render(getSwaggerObject))
   }
 
@@ -233,7 +233,7 @@ object SwaggerJson {
 
   private def _definitionPath(tpe: Swagger.JsonType): String = s"#/definitions/${tpe.name.get}"
 
-  private def _simpleType(tipe: String, format: String, withoutSchema : Boolean): JObject = {
+  private def _simpleType(tipe: String, format: String, withoutSchema: Boolean): JObject = {
     val tpe = ("type" -> tipe) ~
       ("format" -> format)
     if (withoutSchema)
@@ -241,7 +241,7 @@ object SwaggerJson {
     else "schema" -> tpe
   }
 
-  private def _simpleArrayType(tipe: String, format: String, withoutSchema : Boolean): JObject = {
+  private def _simpleArrayType(tipe: String, format: String, withoutSchema: Boolean): JObject = {
     val tpe = ("type" -> "array") ~
       ("items" -> _simpleType(tipe, format, withoutSchema = true))
     if (withoutSchema)
@@ -249,7 +249,7 @@ object SwaggerJson {
     else "schema" -> tpe
   }
 
-  private def _objectArrayType(path: String, withoutSchema : Boolean): JObject = {
+  private def _objectArrayType(path: String, withoutSchema: Boolean): JObject = {
     val tpe = ("type" -> "array") ~
       ("items" -> ("$ref" -> path))
     if (withoutSchema)
@@ -258,14 +258,14 @@ object SwaggerJson {
   }
 
 
-  private def _objectType(path: String, withoutSchema : Boolean): JObject = {
+  private def _objectType(path: String, withoutSchema: Boolean): JObject = {
     val tpe = "$ref" -> path
     if (withoutSchema)
       tpe
     else "schema" -> tpe
   }
 
-  private def _autoJsonType(tpe: Swagger.JsonType, asField : Boolean = false): JObject = {
+  private def _autoJsonType(tpe: Swagger.JsonType, asField: Boolean = false): JObject = {
     _addObjectDefinition(tpe)
     tpe.tpe match {
       case Swagger.JsonType.tpe.obj =>
@@ -299,18 +299,18 @@ object SwaggerJson {
     ("description" -> arg.desc) ~
     ("required"    -> required) ~
     (arg match {
-      case _: SwaggerIntParam      => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32, withoutSchema = true)
-      case _: SwaggerLongParam     => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64, withoutSchema = true)
-      case _: SwaggerFloatParam    => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.float, withoutSchema = true)
-      case _: SwaggerDoubleParam   => _simpleType(Swagger.JsonType.tpe.number, Swagger.JsonType.fmt.double, withoutSchema = true)
-      case _: SwaggerStringParam   => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema = true)
-      case _: SwaggerByteParam     => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.byte, withoutSchema = true)
-      case _: SwaggerBinaryParam   => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.binary, withoutSchema = true)
-      case _: SwaggerBooleanParam  => _simpleType(Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none, withoutSchema = true)
-      case _: SwaggerDateParam     => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.date, withoutSchema = true)
-      case _: SwaggerDateTimeParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.dateTime, withoutSchema = true)
-      case _: SwaggerPasswordParam => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.password, withoutSchema = true)
-      case _: SwaggerFileParam     => _simpleType(Swagger.JsonType.tpe.file, Swagger.JsonType.fmt.none, withoutSchema = true)
+      case _: SwaggerIntParam      => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int32,    withoutSchema = true)
+      case _: SwaggerLongParam     => _simpleType(Swagger.JsonType.tpe.integer, Swagger.JsonType.fmt.int64,    withoutSchema = true)
+      case _: SwaggerFloatParam    => _simpleType(Swagger.JsonType.tpe.number,  Swagger.JsonType.fmt.float,    withoutSchema = true)
+      case _: SwaggerDoubleParam   => _simpleType(Swagger.JsonType.tpe.number,  Swagger.JsonType.fmt.double,   withoutSchema = true)
+      case _: SwaggerStringParam   => _simpleType(Swagger.JsonType.tpe.string,  Swagger.JsonType.fmt.none,     withoutSchema = true)
+      case _: SwaggerByteParam     => _simpleType(Swagger.JsonType.tpe.string,  Swagger.JsonType.fmt.byte,     withoutSchema = true)
+      case _: SwaggerBinaryParam   => _simpleType(Swagger.JsonType.tpe.string,  Swagger.JsonType.fmt.binary,   withoutSchema = true)
+      case _: SwaggerBooleanParam  => _simpleType(Swagger.JsonType.tpe.boolean, Swagger.JsonType.fmt.none,     withoutSchema = true)
+      case _: SwaggerDateParam     => _simpleType(Swagger.JsonType.tpe.string,  Swagger.JsonType.fmt.date,     withoutSchema = true)
+      case _: SwaggerDateTimeParam => _simpleType(Swagger.JsonType.tpe.string,  Swagger.JsonType.fmt.dateTime, withoutSchema = true)
+      case _: SwaggerPasswordParam => _simpleType(Swagger.JsonType.tpe.string,  Swagger.JsonType.fmt.password, withoutSchema = true)
+      case _: SwaggerFileParam     => _simpleType(Swagger.JsonType.tpe.file,    Swagger.JsonType.fmt.none,     withoutSchema = true)
       case _: SwaggerJsonParam     => arg match {
         case argJson: Swagger.JsonBody => _autoJsonType(argJson.tpe)
         case _                         => _simpleType(Swagger.JsonType.tpe.string, Swagger.JsonType.fmt.none, withoutSchema = true)

--- a/src/test/scala/xitrum/annotation/SwaggerReflectionSpec.scala
+++ b/src/test/scala/xitrum/annotation/SwaggerReflectionSpec.scala
@@ -1,0 +1,440 @@
+package xitrum.annotation
+
+import org.scalatest.funspec.AsyncFunSpec
+
+import scala.reflect.runtime.universe.{Type, typeOf}
+
+case class Sub1(name: String, value: Int)
+
+case class Sub2(key: String, value: Boolean)
+
+object Namespace {
+
+  case class Sub(name: String, value: Option[Int])
+
+}
+
+case class Test(
+                 int: Int,
+                 long: Long,
+                 float: Float,
+                 double: Double,
+                 string: String,
+                 boolean: Boolean,
+                 opInt: Option[Int],
+                 opLong: Option[Long],
+                 opFloat: Option[Float],
+                 opDouble: Option[Double],
+                 opString: Option[String],
+                 opBoolean: Option[Boolean],
+                 arrInt: Seq[Int],
+                 arrLong: List[Long],
+                 arrFloat: Array[Float],
+                 arrDouble: Set[Double],
+                 sub: Sub1,
+                 opSub: Option[Sub2],
+                 arrSub1: Seq[Sub1],
+                 arrSub2: Array[Sub2]
+               )
+
+/**
+  * User: smeagol
+  * Date: 09.08.17
+  * Time: 1:47
+  */
+class SwaggerReflectionSpec extends AsyncFunSpec {
+
+  object jsonType {
+    def int(isArray : Boolean = false) = Swagger.JsonType(None, "integer", "int32", isArray = isArray)
+
+    def long(isArray : Boolean = false) = Swagger.JsonType(None, "integer", "int64", isArray = isArray)
+
+    def float(isArray : Boolean = false) = Swagger.JsonType(None, "number", "float", isArray = isArray)
+
+    def double(isArray : Boolean = false) = Swagger.JsonType(None, "number", "double", isArray = isArray)
+
+    def string(isArray : Boolean = false) = Swagger.JsonType(None, "string", isArray = isArray)
+
+    def boolean(isArray : Boolean = false) = Swagger.JsonType(None, "boolean", isArray = isArray)
+
+    def sub1(isArray : Boolean = false) = Swagger.JsonType(Some("Sub1"), "object", fields = Seq(
+      Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired = true),
+      Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"), isRequired = true)
+    ), isArray = isArray)
+
+    def sub2(isArray : Boolean = false) = Swagger.JsonType(Some("Sub2"), "object", fields = Seq(
+      Swagger.JsonField("key", Swagger.JsonType(None, "string"), isRequired = true),
+      Swagger.JsonField("value", Swagger.JsonType(None, "boolean"), isRequired = true)
+    ), isArray = isArray)
+
+    def sub(isArray : Boolean = false) = Swagger.JsonType(Some("Namespace.Sub"), "object", fields = Seq(
+      Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired = true),
+      Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"))
+    ), isArray = isArray)
+
+  }
+
+  describe("SwaggerReflection") {
+
+    describe("_reflectField") {
+
+      val tpe = typeOf[Test]
+
+      def call(field: String): Swagger.JsonField = {
+        val fields = tpe.decls.filter(_.isPublic)
+          .filter(_.isTerm).map(_.asTerm)
+          .filter(_.isGetter)
+        val fld = fields.filter(_.name.toString == field).head
+        SwaggerReflection.reflectField(fld)
+      }
+
+      describe("Simple types") {
+        it("Int") {
+          assertResult(Swagger.JsonField("int", jsonType.int(), isRequired = true)) {
+            call("int")
+          }
+        }
+
+        it("Long") {
+          assertResult(Swagger.JsonField("long", jsonType.long(), isRequired = true)) {
+            call("long")
+          }
+        }
+
+        it("Float") {
+          assertResult(Swagger.JsonField("float", jsonType.float(), isRequired = true)) {
+            call("float")
+          }
+        }
+
+        it("Double") {
+          assertResult(Swagger.JsonField("double", jsonType.double(), isRequired = true)) {
+            call("double")
+          }
+        }
+
+        it("String") {
+          assertResult(Swagger.JsonField("string", jsonType.string(), isRequired = true)) {
+            call("string")
+          }
+        }
+
+        it("Boolean") {
+          assertResult(Swagger.JsonField("boolean", jsonType.boolean(), isRequired = true)) {
+            call("boolean")
+          }
+        }
+
+      }
+
+      describe("Optional simple types") {
+        it("Int") {
+          assertResult(Swagger.JsonField("opInt", jsonType.int())) {
+            call("opInt")
+          }
+        }
+
+        it("Long") {
+          assertResult(Swagger.JsonField("opLong", jsonType.long())) {
+            call("opLong")
+          }
+        }
+
+        it("Float") {
+          assertResult(Swagger.JsonField("opFloat", jsonType.float())) {
+            call("opFloat")
+          }
+        }
+
+        it("Double") {
+          assertResult(Swagger.JsonField("opDouble", jsonType.double())) {
+            call("opDouble")
+          }
+        }
+
+        it("String") {
+          assertResult(Swagger.JsonField("opString", jsonType.string())) {
+            call("opString")
+          }
+        }
+
+        it("Boolean") {
+          assertResult(Swagger.JsonField("opBoolean", jsonType.boolean())) {
+            call("opBoolean")
+          }
+        }
+
+      }
+
+      describe("Simple arrays") {
+        it("Seq") {
+          assertResult(Swagger.JsonField("arrInt", jsonType.int(true), isRequired = true)) {
+            call("arrInt")
+          }
+        }
+
+        it("List") {
+          assertResult(Swagger.JsonField("arrLong", jsonType.long(true), isRequired = true)) {
+            call("arrLong")
+          }
+        }
+
+        it("Array") {
+          assertResult(Swagger.JsonField("arrFloat", jsonType.float(true), isRequired = true)) {
+            call("arrFloat")
+          }
+        }
+
+        it("Set") {
+          assertResult(Swagger.JsonField("arrDouble", jsonType.double(true), isRequired = true)) {
+            call("arrDouble")
+          }
+        }
+
+      }
+
+      describe("Case classes") {
+        it("Sub1") {
+          assertResult(Swagger.JsonField("sub", jsonType.sub1(), isRequired = true)) {
+            call("sub")
+          }
+        }
+      }
+
+      describe("Optional case classes") {
+        it("Sub2") {
+          assertResult(Swagger.JsonField("opSub", jsonType.sub2())) {
+            call("opSub")
+          }
+        }
+
+      }
+
+      describe("Case classes arrays") {
+        it("Seq") {
+          assertResult(Swagger.JsonField("arrSub1", jsonType.sub1(true), isRequired = true)) {
+            call("arrSub1")
+          }
+        }
+
+        it("List") {
+          assertResult(Swagger.JsonField("arrSub2", jsonType.sub2(true), isRequired = true)) {
+            call("arrSub2")
+          }
+        }
+
+      }
+    }
+
+    describe("_reflectTypeFormat") {
+
+      def call(tpe: Type) = SwaggerReflection.reflectTypeFormat(tpe)
+
+      describe("Simple types") {
+        it("Int") {
+          assertResult((None, "integer", "int32")) {
+            call(typeOf[Int])
+          }
+        }
+
+        it("Long") {
+          assertResult((None, "integer", "int64")) {
+            call(typeOf[Long])
+          }
+        }
+
+        it("Float") {
+          assertResult((None, "number", "float")) {
+            call(typeOf[Float])
+          }
+        }
+
+        it("Double") {
+          assertResult((None, "number", "double")) {
+            call(typeOf[Double])
+          }
+        }
+
+        it("String") {
+          assertResult((None, "string", "")) {
+            call(typeOf[String])
+          }
+        }
+
+        it("Boolean") {
+          assertResult((None, "boolean", "")) {
+            call(typeOf[Boolean])
+          }
+        }
+
+      }
+
+      describe("Case classes") {
+        it("Sub1") {
+          assertResult((Some("Sub1"), "object", "")) {
+            call(typeOf[Sub1])
+          }
+        }
+
+        it("Sub2") {
+          assertResult((Some("Sub2"), "object", "")) {
+            call(typeOf[Sub2])
+          }
+        }
+
+        it("Namespace.Sub") {
+          assertResult((Some("Namespace.Sub"), "object", "")) {
+            call(typeOf[Namespace.Sub])
+          }
+        }
+      }
+
+    }
+
+    describe("isArrayType") {
+      def call(tpe: Type) = SwaggerReflection.isArrayType(tpe)
+
+      it("Seq") {
+        assert(call(typeOf[Seq[String]]))
+        assert(call(typeOf[Seq[Int]]))
+        assert(call(typeOf[Seq[(Int, Boolean)]]))
+      }
+
+      it("List") {
+        assert(call(typeOf[List[Float]]))
+        assert(call(typeOf[List[Boolean]]))
+        assert(call(typeOf[List[Sub1]]))
+      }
+
+      it("Array") {
+        assert(call(typeOf[Array[Long]]))
+        assert(call(typeOf[Array[String]]))
+        assert(call(typeOf[Array[Sub2]]))
+      }
+
+      it("Set") {
+        assert(call(typeOf[Set[Long]]))
+        assert(call(typeOf[Set[String]]))
+        assert(call(typeOf[Set[Namespace.Sub]]))
+      }
+    }
+
+    describe("reflect") {
+      def call(tpe: Type) = SwaggerReflection.reflect(tpe)
+
+      describe("Simple Types") {
+        it("Int") {
+          assertResult(jsonType.int()) {
+            call(typeOf[Int])
+          }
+        }
+
+        it("Long") {
+          assertResult(jsonType.long()) {
+            call(typeOf[Long])
+          }
+        }
+
+        it("Float") {
+          assertResult(jsonType.float()) {
+            call(typeOf[Float])
+          }
+        }
+
+        it("Double") {
+          assertResult(jsonType.double()) {
+            call(typeOf[Double])
+          }
+        }
+
+        it("String") {
+          assertResult(jsonType.string()) {
+            call(typeOf[String])
+          }
+        }
+
+        it("Boolean") {
+          assertResult(jsonType.boolean()) {
+            call(typeOf[Boolean])
+          }
+        }
+
+      }
+
+      describe("Simple Arrays") {
+        it("Seq") {
+          assertResult(jsonType.int(true)) {
+            call(typeOf[Seq[Int]])
+          }
+        }
+
+        it("List") {
+          assertResult(jsonType.long(true)) {
+            call(typeOf[List[Long]])
+          }
+        }
+
+        it("Array") {
+          assertResult(jsonType.float(true)) {
+            call(typeOf[Array[Float]])
+          }
+        }
+
+        it("Set") {
+          assertResult(jsonType.double(true)) {
+            call(typeOf[Set[Double]])
+          }
+        }
+
+      }
+
+      describe("Case Classes") {
+        it("Sub1") {
+          assertResult(jsonType.sub1()) {
+            call(typeOf[Sub1])
+          }
+        }
+        it("Sub2") {
+          assertResult(jsonType.sub2()) {
+            call(typeOf[Sub2])
+          }
+        }
+        it("Namespace.Sub") {
+          assertResult(jsonType.sub()) {
+            call(typeOf[Namespace.Sub])
+          }
+        }
+      }
+
+      describe("Case Classes Arrays") {
+        it("Seq") {
+          assertResult(jsonType.sub1(true)) {
+            call(typeOf[Seq[Sub1]])
+          }
+        }
+
+        it("List") {
+          assertResult(jsonType.sub2(true)) {
+            call(typeOf[List[Sub2]])
+          }
+        }
+
+        it("Array") {
+          assertResult(jsonType.sub(true)) {
+            call(typeOf[Array[Namespace.Sub]])
+          }
+        }
+
+        it("Set") {
+          assertResult(jsonType.sub(true)) {
+            call(typeOf[Set[Namespace.Sub]])
+          }
+        }
+
+      }
+    }
+
+  }
+
+}
+

--- a/src/test/scala/xitrum/annotation/SwaggerReflectionSpec.scala
+++ b/src/test/scala/xitrum/annotation/SwaggerReflectionSpec.scala
@@ -9,75 +9,65 @@ case class Sub1(name: String, value: Int)
 case class Sub2(key: String, value: Boolean)
 
 object Namespace {
-
   case class Sub(name: String, value: Option[Int])
-
 }
 
 case class Test(
-                 int: Int,
-                 long: Long,
-                 float: Float,
-                 double: Double,
-                 string: String,
-                 boolean: Boolean,
-                 opInt: Option[Int],
-                 opLong: Option[Long],
-                 opFloat: Option[Float],
-                 opDouble: Option[Double],
-                 opString: Option[String],
-                 opBoolean: Option[Boolean],
-                 arrInt: Seq[Int],
-                 arrLong: List[Long],
-                 arrFloat: Array[Float],
-                 arrDouble: Set[Double],
-                 sub: Sub1,
-                 opSub: Option[Sub2],
-                 arrSub1: Seq[Sub1],
-                 arrSub2: Array[Sub2]
-               )
+  int:       Int,
+  long:      Long,
+  float:     Float,
+  double:    Double,
+  string:    String,
+  boolean:   Boolean,
+  opInt:     Option[Int],
+  opLong:    Option[Long],
+  opFloat:   Option[Float],
+  opDouble:  Option[Double],
+  opString:  Option[String],
+  opBoolean: Option[Boolean],
+  arrInt:    Seq[Int],
+  arrLong:   List[Long],
+  arrFloat:  Array[Float],
+  arrDouble: Set[Double],
+  sub:       Sub1,
+  opSub:     Option[Sub2],
+  arrSub1:   Seq[Sub1],
+  arrSub2:   Array[Sub2]
+)
 
-/**
-  * User: smeagol
-  * Date: 09.08.17
-  * Time: 1:47
-  */
 class SwaggerReflectionSpec extends AsyncFunSpec {
-
   object jsonType {
-    def int(isArray : Boolean = false) = Swagger.JsonType(None, "integer", "int32", isArray = isArray)
+    def int(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(None, "integer", "int32", isArray = isArray)
 
-    def long(isArray : Boolean = false) = Swagger.JsonType(None, "integer", "int64", isArray = isArray)
+    def long(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(None, "integer", "int64", isArray = isArray)
 
-    def float(isArray : Boolean = false) = Swagger.JsonType(None, "number", "float", isArray = isArray)
+    def float(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(None, "number", "float", isArray = isArray)
 
-    def double(isArray : Boolean = false) = Swagger.JsonType(None, "number", "double", isArray = isArray)
+    def double(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(None, "number", "double", isArray = isArray)
 
-    def string(isArray : Boolean = false) = Swagger.JsonType(None, "string", isArray = isArray)
+    def string(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(None, "string", isArray = isArray)
 
-    def boolean(isArray : Boolean = false) = Swagger.JsonType(None, "boolean", isArray = isArray)
+    def boolean(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(None, "boolean", isArray = isArray)
 
-    def sub1(isArray : Boolean = false) = Swagger.JsonType(Some("Sub1"), "object", fields = Seq(
+    def sub1(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(Some("Sub1"), "object", fields = Seq(
       Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired = true),
       Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"), isRequired = true)
     ), isArray = isArray)
 
-    def sub2(isArray : Boolean = false) = Swagger.JsonType(Some("Sub2"), "object", fields = Seq(
+    def sub2(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(Some("Sub2"), "object", fields = Seq(
       Swagger.JsonField("key", Swagger.JsonType(None, "string"), isRequired = true),
       Swagger.JsonField("value", Swagger.JsonType(None, "boolean"), isRequired = true)
     ), isArray = isArray)
 
-    def sub(isArray : Boolean = false) = Swagger.JsonType(Some("Namespace.Sub"), "object", fields = Seq(
+    def sub(isArray : Boolean = false): Swagger.JsonType = Swagger.JsonType(Some("Namespace.Sub"), "object", fields = Seq(
       Swagger.JsonField("name", Swagger.JsonType(None, "string"), isRequired = true),
       Swagger.JsonField("value", Swagger.JsonType(None, "integer", "int32"))
     ), isArray = isArray)
-
   }
 
   describe("SwaggerReflection") {
 
     describe("_reflectField") {
-
       val tpe = typeOf[Test]
 
       def call(field: String): Swagger.JsonField = {
@@ -124,7 +114,6 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call("boolean")
           }
         }
-
       }
 
       describe("Optional simple types") {
@@ -163,7 +152,6 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call("opBoolean")
           }
         }
-
       }
 
       describe("Simple arrays") {
@@ -190,7 +178,6 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call("arrDouble")
           }
         }
-
       }
 
       describe("Case classes") {
@@ -207,7 +194,6 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call("opSub")
           }
         }
-
       }
 
       describe("Case classes arrays") {
@@ -222,12 +208,10 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call("arrSub2")
           }
         }
-
       }
     }
 
     describe("_reflectTypeFormat") {
-
       def call(tpe: Type) = SwaggerReflection.reflectTypeFormat(tpe)
 
       describe("Simple types") {
@@ -266,7 +250,6 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call(typeOf[Boolean])
           }
         }
-
       }
 
       describe("Case classes") {
@@ -288,7 +271,6 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
           }
         }
       }
-
     }
 
     describe("isArrayType") {
@@ -358,7 +340,6 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call(typeOf[Boolean])
           }
         }
-
       }
 
       describe("Simple Arrays") {
@@ -385,7 +366,6 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call(typeOf[Set[Double]])
           }
         }
-
       }
 
       describe("Case Classes") {
@@ -430,11 +410,7 @@ class SwaggerReflectionSpec extends AsyncFunSpec {
             call(typeOf[Set[Namespace.Sub]])
           }
         }
-
       }
     }
-
   }
-
 }
-


### PR DESCRIPTION
This patch allows to document JSON models from case classes with Swagger like this example:

```scala
package quickstart.action

import java.util.Date

import xitrum.FutureAction
import xitrum.annotation.{POST, Swagger}
import xitrum.util.SeriDeseri

@POST("api/test")
@Swagger(
	Swagger.JsonBody("request", "This is request model", Test.RequestType),
	Swagger.Response(200, "Success", Some(Test.ResponseType)),
	Swagger.Response(201, "Success", Some(Test.ResponseArrayType)),
	Swagger.Response(404, "Not found")
)
class Test extends FutureAction {
	override def execute(): Unit = {
		SeriDeseri.fromJValue[Test.Request](requestContentJValue) match {
			case Some(req) => // do something useful
			case None => // reply 404 or something
		}
	}
}

object Test {

	case class Sub(subValue: Option[Int])

	case class Response(value: String, sub: Sub)

	case class Request(integer: Int,
	                   long: Long,
	                   float: Float,
	                   double: Double,
	                   string: String,
	                   boolean: Boolean,
	                   dateTime: Date,
	                   optional: Option[String],
	                   list: List[String],
	                   seq: Seq[Sub],
	                   obj: Sub
	                  )

	val RequestType = Swagger.arrayOf[Request]
	val ResponseType = Swagger.valueOf[Response]
	val ResponseArrayType = Swagger.arrayOf[Response]
}
```

And this code will produce following swagger.json
```json
{
  "swagger" : "2.0",
  "info" : {
    "title" : "APIs documented by Swagger",
    "version" : "1.0-SNAPSHOT"
  },
  "basePath" : "/",
  "paths" : {
    "/api/test" : {
      "post" : {
        "operationId" : "test",
        "parameters" : [ {
          "name" : "request",
          "in" : "body",
          "description" : "This is request model",
          "required" : true,
          "schema" : {
            "type" : "array",
            "items" : {
              "$ref" : "#/definitions/Test.Request"
            }
          }
        } ],
        "responses" : {
          "200" : {
            "description" : "Success",
            "schema" : {
              "$ref" : "#/definitions/Test.Response"
            }
          },
          "201" : {
            "description" : "Success",
            "schema" : {
              "type" : "array",
              "items" : {
                "$ref" : "#/definitions/Test.Response"
              }
            }
          },
          "404" : {
            "description" : "Not found"
          }
        }
      }
    }
  },
  "definitions" : {
    "Test.Request" : {
      "type" : "object",
      "properties" : {
        "integer" : {
          "type" : "integer",
          "format" : "int32"
        },
        "long" : {
          "type" : "integer",
          "format" : "int64"
        },
        "float" : {
          "type" : "number",
          "format" : "float"
        },
        "double" : {
          "type" : "number",
          "format" : "double"
        },
        "string" : {
          "type" : "string",
          "format" : ""
        },
        "boolean" : {
          "type" : "boolean",
          "format" : ""
        },
        "dateTime" : {
          "type" : "string",
          "format" : "date-time"
        },
        "optional" : {
          "type" : "string",
          "format" : ""
        },
        "list" : {
          "type" : "array",
          "items" : {
            "type" : "string",
            "format" : ""
          }
        },
        "seq" : {
          "type" : "array",
          "items" : {
            "$ref" : "#/definitions/Test.Sub"
          }
        },
        "obj" : {
          "$ref" : "#/definitions/Test.Sub"
        }
      },
      "required" : [ "integer", "long", "float", "double", "string", "boolean", "dateTime", "list", "seq", "obj" ]
    },
    "Test.Sub" : {
      "type" : "object",
      "properties" : {
        "subValue" : {
          "type" : "integer",
          "format" : "int32"
        }
      }
    },
    "Test.Response" : {
      "type" : "object",
      "properties" : {
        "value" : {
          "type" : "string",
          "format" : ""
        },
        "sub" : {
          "$ref" : "#/definitions/Test.Sub"
        }
      },
      "required" : [ "value", "sub" ]
    }
  }
}
```

You may want to load that json to [Swagger Online Editor](http://editor.swagger.io/) to check how the documentation looks like.

This patch supports simple case classes as models (not sure about inheritance and other advanced features), `Seq`, `List`, `Set` as array types, `Option` for non-mandatory fields.